### PR TITLE
Add SQLServerInfo Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ There are cases where a MS SQL Server might not be listening on a standard TCP p
 ## Standard Modules
 Standard modules are used to interact against a single MS SQL server.
 
+* <b>info</b> - Print information about the SQL Service
 * <b>query -o QUERY</b> - Execute an arbitrary SQL query
 * <b>whoami</b> - See what user you are logged in as, mapped as and what roles exist
 * <b>databases</b> - Show all databases present on the SQL server
@@ -112,9 +113,15 @@ The below techniques are on the roadmap for future releases
 
 ## History
 <details>
+<summary>v2.1.6</summary>
+
+* Added 'info' module, '-m info'.
+</details>
+
+<details>
 <summary>v2.1.5</summary>
 
-* Added option to enumerate domain SPNS (-e).
+* Added option to enumerate domain SPNs (-e).
 </details>
 
 <details>

--- a/SQLRecon/SQLRecon/Modules/SQLServerInfo.cs
+++ b/SQLRecon/SQLRecon/Modules/SQLServerInfo.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Data.SqlClient;
+
+namespace SQLRecon.Modules;
+
+public class SQLServerInfo
+{
+    public string ComputerName { get; set; }
+    public string DomainName { get; set; }
+    public string ServicePid { get; set; }
+    public string ServiceName { get; set; }
+    public string ServiceAccount { get; set; }
+    public string AuthenticationMode { get; set; }
+    public string ForcedEncryption { get; set; }
+    public string Clustered { get; set; }
+    public string SqlServerVersionNumber { get; set; }
+    public string SqlServerMajorVersion { get; set; }
+    public string SqlServerEdition { get; set; }
+    public string SqlServerServicePack { get; set; }
+    public string OsArchitecture { get; set; }
+    public string OsMachineType { get; set; }
+    public string OsVersion { get; set; }
+    public string OsVersionNumber { get; set; }
+    public string CurrentLogin { get; set; }
+    public string IsSysAdmin { get; set; }
+    public string ActiveSessions { get; set; }
+
+    private readonly SqlConnection _connection;
+
+    public SQLServerInfo(SqlConnection connection)
+    {
+        _connection = connection;
+    }
+
+    public void GetAllSQLServerInfo()
+    {
+        var roles = new Roles();
+        var sysadmin = roles.CheckServerRole(_connection, "sysadmin");
+
+        IsSysAdmin = sysadmin ? "Yes" : "No";
+        
+        ComputerName = GetComputerName();
+        DomainName = GetDomainName();
+        ServicePid = GetServicePid();
+
+        if (sysadmin)
+        {
+            OsMachineType = GetOsMachineType();
+            OsVersion = GetOsVersion();
+        }
+
+        ServiceName = GetSqlServerServiceName();
+        ServiceAccount = GetSqlServiceAccountName();
+        AuthenticationMode = GetAuthenticationMode();
+        ForcedEncryption = GetForcedEncryption();
+        Clustered = GetClustered();
+        SqlServerVersionNumber = GetSqlVersionNumber();
+        SqlServerMajorVersion = GetSqlMajorVersionNumber();
+        SqlServerEdition = GetSqlServerEdition();
+        SqlServerServicePack = GetSqlServerServicePack();
+        OsArchitecture = GetOsArchitecture();
+        OsVersionNumber = GetOsVersionNumber();
+        CurrentLogin = GetCurrentLogon();
+        ActiveSessions = GetActiveSessions();
+    }
+
+    public void PrintInfo()
+    {
+        Console.WriteLine();
+        Console.WriteLine("ComputerName:           {0}", ComputerName);
+        Console.WriteLine("DomainName:             {0}", DomainName);
+        Console.WriteLine("ServicePid:             {0}", ServicePid);
+        Console.WriteLine("ServiceName:            {0}", ServiceName);
+        Console.WriteLine("ServiceAccount:         {0}", ServiceAccount);
+        Console.WriteLine("AuthenticationMode:     {0}", AuthenticationMode);
+        Console.WriteLine("ForcedEncryption:       {0}", ForcedEncryption);
+        Console.WriteLine("Clustered:              {0}", Clustered);
+        Console.WriteLine("SqlServerVersionNumber: {0}", SqlServerVersionNumber);
+        Console.WriteLine("SqlServerMajorVersion:  {0}", SqlServerMajorVersion);
+        Console.WriteLine("SqlServerEdition:       {0}", SqlServerEdition);
+        Console.WriteLine("SqlServerServicePack:   {0}", SqlServerServicePack);
+        Console.WriteLine("OsArchitecture:         {0}", OsArchitecture);
+        
+        if (!string.IsNullOrEmpty(OsMachineType))
+            Console.WriteLine("OsMachineType:          {0}", OsMachineType);
+        
+        if (!string.IsNullOrEmpty(OsVersion))
+            Console.WriteLine("OsVersion:              {0}", OsVersion);
+
+        Console.WriteLine("OsVersionNumber:        {0}", OsVersionNumber);
+        Console.WriteLine("CurrentLogin:           {0}", CurrentLogin);
+        Console.WriteLine("IsSysAdmin:             {0}", IsSysAdmin);
+        Console.WriteLine("ActiveSessions:         {0}", ActiveSessions);
+    }
+
+    public string GetComputerName()
+    {
+        var query = new SQLQuery();
+        return query.ExecuteQuery(_connection, "SELECT @@SERVERNAME;").TrimStart('\n');
+    }
+
+    public string GetDomainName()
+    {
+        var query = new SQLQuery();
+        return query.ExecuteQuery(_connection, "SELECT DEFAULT_DOMAIN();").TrimStart('\n');
+    }
+
+    public string GetServicePid()
+    {
+        var query = new SQLQuery();
+        return query.ExecuteQuery(_connection, "SELECT SERVERPROPERTY('processid');").TrimStart('\n');
+    }
+
+    public string GetOsVersion()
+    {
+        var query = new SQLQuery();
+        return query.ExecuteQuery(_connection, @"DECLARE @ProductName  SYSNAME
+EXECUTE master.dbo.xp_regread
+@rootkey		= N'HKEY_LOCAL_MACHINE',
+@key			= N'SOFTWARE\Microsoft\Windows NT\CurrentVersion',
+@value_name		= N'ProductName',
+@value			= @ProductName output
+SELECT @ProductName;").TrimStart('\n');
+    }
+
+    public string GetSqlServerServiceName()
+    {
+        var query = new SQLQuery();
+        return query.ExecuteQuery(_connection, @"DECLARE @SQLServerServiceName varchar(250)
+DECLARE @SQLServerInstance varchar(250)
+if @@SERVICENAME = 'MSSQLSERVER'
+BEGIN
+set @SQLServerInstance = 'SYSTEM\CurrentControlSet\Services\MSSQLSERVER'
+set @SQLServerServiceName = 'MSSQLSERVER'
+END
+ELSE
+BEGIN
+set @SQLServerInstance = 'SYSTEM\CurrentControlSet\Services\MSSQL$'+cast(@@SERVICENAME as varchar(250))
+set @SQLServerServiceName = 'MSSQL$'+cast(@@SERVICENAME as varchar(250))
+END
+SELECT @SQLServerServiceName;").TrimStart('\n');
+    }
+
+    public string GetSqlServiceAccountName()
+    {
+        var query = new SQLQuery();
+        return query.ExecuteQuery(_connection, @"DECLARE @SQLServerInstance varchar(250)
+if @@SERVICENAME = 'MSSQLSERVER'
+BEGIN
+set @SQLServerInstance = 'SYSTEM\CurrentControlSet\Services\MSSQLSERVER'
+END
+ELSE
+BEGIN
+set @SQLServerInstance = 'SYSTEM\CurrentControlSet\Services\MSSQL$'+cast(@@SERVICENAME as varchar(250))
+END
+
+DECLARE @ServiceAccountName varchar(250)
+EXECUTE master.dbo.xp_instance_regread
+N'HKEY_LOCAL_MACHINE', @SQLServerInstance,
+N'ObjectName',@ServiceAccountName OUTPUT, N'no_output'
+SELECT @ServiceAccountName;").TrimStart('\n');
+    }
+
+    public string GetAuthenticationMode()
+    {
+        var query = new SQLQuery();
+        return query.ExecuteQuery(_connection, @"DECLARE @AuthenticationMode INT
+EXEC master.dbo.xp_instance_regread N'HKEY_LOCAL_MACHINE',
+N'Software\Microsoft\MSSQLServer\MSSQLServer',
+N'LoginMode', @AuthenticationMode OUTPUT
+
+(SELECT CASE @AuthenticationMode
+WHEN 1 THEN 'Windows Authentication'
+WHEN 2 THEN 'Windows and SQL Server Authentication'
+ELSE 'Unknown'
+END);").TrimStart('\n');
+    }
+
+    public string GetForcedEncryption()
+    {
+        var query = new SQLQuery();
+        return query.ExecuteQuery(_connection, @"BEGIN TRY 
+DECLARE @ForcedEncryption INT
+EXEC master.dbo.xp_instance_regread N'HKEY_LOCAL_MACHINE',
+N'SOFTWARE\MICROSOFT\Microsoft SQL Server\MSSQLServer\SuperSocketNetLib',
+N'ForceEncryption', @ForcedEncryption OUTPUT
+END TRY
+BEGIN CATCH	            
+END CATCH
+SELECT @ForcedEncryption;").TrimStart('\n');
+    }
+
+    public string GetClustered()
+    {
+        var query = new SQLQuery();
+        return query.ExecuteQuery(_connection, @"SELECT CASE  SERVERPROPERTY('IsClustered')
+WHEN 0
+THEN 'No'
+ELSE 'Yes'
+END").TrimStart('\n');
+    }
+
+    public string GetSqlVersionNumber()
+    {
+        var query = new SQLQuery();
+        return query.ExecuteQuery(_connection, @"SELECT SERVERPROPERTY('productversion');").TrimStart('\n');
+    }
+    
+    public string GetSqlMajorVersionNumber()
+    {
+        var query = new SQLQuery();
+        return query.ExecuteQuery(_connection, @"SELECT SUBSTRING(@@VERSION, CHARINDEX('2', @@VERSION), 4);").TrimStart('\n');
+    }
+    
+    public string GetSqlServerEdition()
+    {
+        var query = new SQLQuery();
+        return query.ExecuteQuery(_connection, @"SELECT SERVERPROPERTY('Edition');").TrimStart('\n');
+    }
+
+    public string GetSqlServerServicePack()
+    {
+        var query = new SQLQuery();
+        return query.ExecuteQuery(_connection, @"SELECT SERVERPROPERTY('ProductLevel');").TrimStart('\n');
+    }
+
+    public string GetOsMachineType()
+    {
+        var query = new SQLQuery();
+        return query.ExecuteQuery(_connection, @"DECLARE @MachineType  SYSNAME
+EXECUTE master.dbo.xp_regread
+@rootkey		= N'HKEY_LOCAL_MACHINE',
+@key			= N'SYSTEM\CurrentControlSet\Control\ProductOptions',
+@value_name		= N'ProductType',
+@value			= @MachineType output
+SELECT @MachineType;").TrimStart('\n');
+    }
+    
+    public string GetOsArchitecture()
+    {
+        var query = new SQLQuery();
+        return query.ExecuteQuery(_connection, @"SELECT SUBSTRING(@@VERSION, CHARINDEX('x', @@VERSION), 3);").TrimStart('\n');
+    }
+    
+    public string GetOsVersionNumber()
+    {
+        var query = new SQLQuery();
+        return query.ExecuteQuery(_connection, @"SELECT RIGHT(SUBSTRING(@@VERSION, CHARINDEX('Windows Server', @@VERSION), 19), 4);").TrimStart('\n');
+    }
+    
+    public string GetCurrentLogon()
+    {
+        var query = new SQLQuery();
+        return query.ExecuteQuery(_connection, @"SELECT SYSTEM_USER;").TrimStart('\n');
+    }
+
+    public string GetActiveSessions()
+    {
+        var query = new SQLQuery();
+        return query.ExecuteQuery(_connection, @"SELECT COUNT(*) FROM [sys].[dm_exec_sessions] WHERE status = 'running';").TrimStart('\n');
+    }
+}

--- a/SQLRecon/SQLRecon/Program.cs
+++ b/SQLRecon/SQLRecon/Program.cs
@@ -17,7 +17,7 @@ namespace SQLRecon
                 // print help if no arguments are supplieds
                 if ((args.Length > 0 && argDict.Count == 0) || argDict.ContainsKey("h"))
                 {
-                    Help Help = new Help(); 
+                    Help.Show(); 
                     return;
                 }
 

--- a/SQLRecon/SQLRecon/Properties/AssemblyInfo.cs
+++ b/SQLRecon/SQLRecon/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.5.0")]
-[assembly: AssemblyFileVersion("2.1.5.0")]
+[assembly: AssemblyVersion("2.1.6.0")]
+[assembly: AssemblyFileVersion("2.1.6.0")]

--- a/SQLRecon/SQLRecon/SQLRecon.csproj
+++ b/SQLRecon/SQLRecon/SQLRecon.csproj
@@ -113,6 +113,7 @@
     <Compile Include="modules\Help.cs" />
     <Compile Include="modules\CLRAssemblies.cs" />
     <Compile Include="modules\OLECmdExec.cs" />
+    <Compile Include="modules\SQLServerInfo.cs" />
     <Compile Include="modules\XPCmdShell.cs" />
     <Compile Include="modules\Roles.cs" />
     <Compile Include="modules\ExecuteQuery.cs" />

--- a/SQLRecon/SQLRecon/modules/Help.cs
+++ b/SQLRecon/SQLRecon/modules/Help.cs
@@ -2,15 +2,12 @@
 
 namespace SQLRecon.Modules
 {
-    public class Help
+    public static class Help
     {
-        public Help()
-        {
-            initialize();
-        }
-
-        // this returns the help menu to console
-        public void initialize()
+        /// <summary>
+        /// Prints the help menu to console
+        /// </summary>
+        public static void Show()
         {
             Console.WriteLine("");
             Console.WriteLine("SQLRecon v2.1.5");
@@ -47,6 +44,7 @@ namespace SQLRecon.Modules
             Console.WriteLine("");
 
             Console.WriteLine("Standard Modules (-m):");
+            Console.WriteLine("\t[+] info | Show information about the SQL Server");
             Console.WriteLine("\t[+] query -o QUERY | Execute an arbitrary SQL query");
             Console.WriteLine("\t[+] whoami | See what user you are logged in as, mapped as and what roles exist");
             Console.WriteLine("\t[+] databases | Show all databases present on the SQL server");

--- a/SQLRecon/SQLRecon/modules/Help.cs
+++ b/SQLRecon/SQLRecon/modules/Help.cs
@@ -23,7 +23,7 @@ namespace SQLRecon.Modules
 
             Console.WriteLine("-a Windows - Use Windows authentication. This uses the current users token.");
             Console.WriteLine("\t[+] -s SERVERNAME | SQL server hostname");
-            Console.WriteLine("\t[+] -d DATABASE | SQL server database name");
+            Console.WriteLine("\t[+] -d DATABASE | (OPTIONAL) SQL server database name. Defaults to 'master'");
             Console.WriteLine("\t[+] -r PORT | (OPTIONAL) Defaults to 1433");            
             Console.WriteLine("");
 

--- a/SQLRecon/SQLRecon/modules/Roles.cs
+++ b/SQLRecon/SQLRecon/modules/Roles.cs
@@ -1,47 +1,74 @@
 ﻿using System;
 using System.Data.SqlClient;
 
-namespace SQLRecon.Modules
+namespace SQLRecon.Modules;
+
+public class Roles
 {
-    public class Roles
+    private readonly SQLQuery _sqlQuery = new();
+
+    /// <summary>
+    /// Check to see if a user is part of a role
+    /// </summary>
+    /// <param name="con"></param>
+    /// <param name="role"></param>
+    /// <param name="print"></param>
+    /// <returns></returns>
+    public bool CheckServerRole(SqlConnection con, string role, bool print = false)
     {
-        SQLQuery sqlQuery = new SQLQuery();
+        var output = _sqlQuery.ExecuteQuery(con,"SELECT IS_SRVROLEMEMBER('" + role + "');").TrimStart('\n');
+        
+        if (print)
+            RoleResult(role, output);
+        
+        return output.Equals("1");
+    }
 
-        // this will check to see if a user is part of a role
-        public void Server(SqlConnection con, String role)
+    /// <summary>
+    /// Check to see if a user is part of a role on a linked SQL server
+    /// </summary>
+    /// <param name="con"></param>
+    /// <param name="role"></param>
+    /// <param name="linkedSQLServer"></param>
+    /// <param name="print"></param>
+    /// <returns></returns>
+    public bool CheckLinkedServerRole(SqlConnection con, string role, string linkedSQLServer, bool print = false)
+    {
+        var output = _sqlQuery.ExecuteQuery(con, "select * from openquery(\"" + linkedSQLServer + "\", 'SELECT IS_SRVROLEMEMBER(''" + role + "'');')").TrimStart('\n');
+        
+        if (print)
+            RoleResult(role, output);
+        
+        return output.Equals("1");
+    }
+
+    /// <summary>
+    /// Check the roles of an impersonated user 
+    /// </summary>
+    /// <param name="con"></param>
+    /// <param name="role"></param>
+    /// <param name="impersonate"></param>
+    /// <param name="print"></param>
+    /// <returns></returns>
+    public bool CheckImpersonatedRole(SqlConnection con, string role, string impersonate, bool print = false)
+    {
+        var output = _sqlQuery.ExecuteQuery(con, "EXECUTE AS LOGIN = '" + impersonate + "';SELECT IS_SRVROLEMEMBER('" + role + "');").TrimStart('\n');
+        
+        if (print)
+            RoleResult(role, output);
+        
+        return output.Equals("1");
+    }
+
+    private static void RoleResult(string role, string sqlOutput)
+    {
+        if (sqlOutput.Equals("1"))
         {
-            string sqlOutput = "";
-            sqlOutput = sqlQuery.ExecuteQuery(con,"SELECT IS_SRVROLEMEMBER('" + role + "');");
-            RoleResult(role, sqlOutput);
+            Console.WriteLine("User is a member of " + role + " role");
         }
-
-        // this will check to see if a user is part of a role on a linked SQL server
-        public void Linked(SqlConnection con, String role, String linkedSQLServer)
+        else
         {
-            string sqlOutput = "";
-            sqlOutput = sqlQuery.ExecuteQuery(con, "select * from openquery(\"" + linkedSQLServer + "\", 'SELECT IS_SRVROLEMEMBER(''" + role +"'');')");
-            RoleResult(role, sqlOutput);
-        }
-
-        // this will check the roles of an impersonated user
-        public void Impersonate(SqlConnection con, String role, String impersonate)
-        {
-            string sqlOutput = "";
-            sqlOutput = sqlQuery.ExecuteQuery(con, "EXECUTE AS LOGIN = '" + impersonate + "';SELECT IS_SRVROLEMEMBER('" + role + "');");
-            RoleResult(role, sqlOutput);
-        }
-
-        public void RoleResult(string role, string sqlOutput)
-        {
-            if (sqlOutput.Contains("1"))
-            {
-                Console.WriteLine("User is a member of " + role + " role");
-            }
-            else
-            {
-                Console.WriteLine("User is NOT a member of " + role + " role\n");
-            }
+            Console.WriteLine("User is NOT a member of " + role + " role\n");
         }
     }
 }
-


### PR DESCRIPTION
This PR adds a new module to print information about a target SQL instance.  Functionality is taken from PowerUpSQL's `Get-SQLServerInfo`.

```
PS C:\SQLRecon> .\SQLRecon.exe -a windows -s sql-1.testlab.local -m info

ComputerName:           sql-1
DomainName:             LAB
ServicePid:             3132
ServiceName:            MSSQLSERVER
ServiceAccount:         LAB\mssql_svc
AuthenticationMode:     Windows Authentication
ForcedEncryption:       0
Clustered:              No
SqlServerVersionNumber: 16.0.1000.6
SqlServerMajorVersion:  2022
SqlServerEdition:       Standard Edition (64-bit)
SqlServerServicePack:   RTM
OsArchitecture:         X64
OsVersionNumber:        2022
CurrentLogin:           LAB\rasta
IsSysAdmin:             No
ActiveSessions:         1
```

A few other minor changes include:
- The `database` parameter is now optional and defaults to "master".
- Methods in the `Roles` class now returns a `bool` and include an optional override for printing the output to the console.  This was useful so you can do things like:

```c#
var isSysadmin = roles.CheckServerRole(_connection, "sysadmin");

if (isSysadmin)
{
    // do something
}
```

Comments and feedback welcome.