### PR TITLE
Fix impersonation failure for `sysadmin` users in `SQLModules.cs`

### DIFF
--- a/SQLRecon/SQLRecon/commands/SqlModules.cs
+++ b/SQLRecon/SQLRecon/commands/SqlModules.cs
@@ -553,11 +553,13 @@ namespace SQLRecon.Commands
             // Extract all user names
             List<string> logins = Print.ExtractColumnValues(_query, "name");
 
-            Dictionary<string, string> impersonationLogins = new Dictionary<string, string>();
+            Dictionary<string, string> impersonationLogins = new();
 
             // Next check to see if the user is a sysadmin
             if (Roles.CheckRoleMembership(Var.Connect, "sysadmin"))
             {
+                // If the user is a sysadmin, they can impersonate any login
+                Print.Status("Current user is a sysadmin and can impersonate any account.", true);
                 if (logins.Any())
                 {
                     foreach (string login in logins)
@@ -568,6 +570,7 @@ namespace SQLRecon.Commands
             }
             else
             {
+                // If not a sysadmin, enumerate all users and check which ones can be impersonated
                 if (logins.Any())
                 {
                     foreach (string login in logins)
@@ -577,6 +580,9 @@ namespace SQLRecon.Commands
                         if (canImpersonate)
                         {
                             impersonationLogins.Add(login, "True");
+                        } else
+                        {
+                            impersonationLogins.Add(login, "False");
                         }
                     }
                 }
@@ -1070,17 +1076,17 @@ namespace SQLRecon.Commands
                     case "standard":
                         return true;
                     case "impersonation":
+                        
                         // Check to see if the supplied user can be impersonated.
                         if (Roles.CheckImpersonation(Var.Connect, Var.Impersonate))
                         {
                             return true;
                         }
-                        else
-                        {
-                            // Go no further
-                            Print.Error($"'{Var.Impersonate}' can not be impersonated on {Var.SqlServer}.", true);
-                            return false;
-                        }
+
+                        // Go no further
+                        Print.Error($"'{Var.Impersonate}' can not be impersonated on {Var.SqlServer}.", true);
+                        return false;
+
                     case "linked" or "chained":
                         // Obtain a list linked SQL servers
                         string sqlOutput = Sql.CustomQuery(Var.Connect, Query.GetLinkedSqlServers);

--- a/SQLRecon/SQLRecon/modules/Info.cs
+++ b/SQLRecon/SQLRecon/modules/Info.cs
@@ -100,7 +100,7 @@ namespace SQLRecon.Modules
                 { "ActiveSessions", Query.GetActiveSessions }
             };
             
-            // Check to see if the user is a sysadmin. Consider linked SQL srver chains.
+            // Check to see if the user is a sysadmin. Consider linked SQL server chains.
             bool sysadmin = (linkedSqlServerChain == null)
                 ? Roles.CheckLinkedRoleMembership(Var.Connect, "sysadmin", linkedSqlServer)
                 : Roles.CheckLinkedRoleMembership(Var.Connect, "sysadmin", null, linkedSqlServerChain);

--- a/SQLRecon/SQLRecon/modules/Roles.cs
+++ b/SQLRecon/SQLRecon/modules/Roles.cs
@@ -206,10 +206,17 @@ namespace SQLRecon.Modules
         /// <returns></returns>
         internal static bool CheckImpersonation(SqlConnection con, string user)
         {
+
+            // If the user is a sysadmin, return true, as they can impersonate any user.
+            if (Roles.CheckRoleMembership(Var.Connect, "sysadmin"))
+            {
+                return true;
+            }
+
             user = user.Replace("'", "''");
-            
+
             // Check if a specific user can be impersonated
-            return Sql.Query(con,string.Format(Query.CheckImpersonation, user)).Equals("1");
+            return Sql.Query(con, string.Format(Query.CheckImpersonation, user)).Equals("1");
         }
 
         /// <summary>


### PR DESCRIPTION
This PR addresses an issue with impersonation in `SQLModules.cs`, specifically within the `Roles.CheckImpersonation` method. The current implementation fails to account for the fact that users with the `sysadmin` role can impersonate any user without restrictions. This oversight results in impersonation failures, even when the current user has sufficient privileges.

![image](https://github.com/user-attachments/assets/682dc85c-6153-4ba7-85d3-31472bbf16cc)

## Screenshots

### Before Fix

![image](https://github.com/user-attachments/assets/45a58532-6149-40aa-af88-a67c70f7455f)

### After the Fix
Impersonation works as expected for sysadmin users:
![image](https://github.com/user-attachments/assets/7ed46dac-dd3e-47b8-a9a8-5eb535db2bd4)
