### PR TITLE
Allow sysadmins to use impersonation

### DIFF
--- a/SQLRecon/SQLRecon/commands/SqlModules.cs
+++ b/SQLRecon/SQLRecon/commands/SqlModules.cs
@@ -1071,7 +1071,7 @@ namespace SQLRecon.Commands
                         return true;
                     case "impersonation":
                         // Check to see if the supplied user can be impersonated.
-                        if (Roles.CheckImpersonation(Var.Connect, Var.Impersonate))
+                        if (Roles.CheckImpersonation(Var.Connect, Var.Impersonate) || Roles.CheckRoleMembership(Var.Connect, "sysadmin"))
                         {
                             return true;
                         }


### PR DESCRIPTION
When accessing a server as `sysadmin`, the `impersonate` module correctly identifies other users as impersonateable. Trying to actually do so with the `/iuser` flag errors out during context checking though: 

```
'webapp11' can not be impersonated on sql11.
```

Comparing the code reveals, that the impersonate module checks for the sysadmin role OR explicit impersonation permissions. The context check carried out before users actually get impersonated in turn ONLY checks for explicitly granted permissions and thus disregards the implicit sysadmin permissions. This results in the shown error. 

The issue was fixed by adding the sysadmin check to the context check. 