### PR TITLE
remove sAMAccountName filter containing SAM_USER_OBJECT

### DIFF
--- a/SQLRecon/SQLRecon/modules/GetDomainSPNs.cs
+++ b/SQLRecon/SQLRecon/modules/GetDomainSPNs.cs
@@ -23,7 +23,7 @@ namespace SQLRecon.Modules
 
             Ldap ldap = new Ldap(searcher);
 
-            const string ldapFilter = "(&(sAMAccountType=805306368)(servicePrincipalName=MSSQL*))";
+            const string ldapFilter = "(servicePrincipalName=MSSQL*)";
             string[] properties = new[] { "cn", "samaccountname", "objectsid", "serviceprincipalname", "lastlogon" };
 
             Dictionary<string, Dictionary<string, object[]>> results = ldap.ExecuteLdapQuery(ldapFilter, properties);


### PR DESCRIPTION
Small edit to the `ldapFilter` string used by the SqlSpns enum module to allow return of machine accounts and other object types that have MSSQL SPNs. Current filter looks for user accounts only, similar to a Kerberoasting recon filter.

May be related to issue reported in #12 